### PR TITLE
Rename executable binary and default repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 *~
-indexer-reference-provider
+index-provider

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN if test "${INIT_PROVIDER}" = 'false'; then /go/bin/provider init; else echo 
 
 FROM gcr.io/distroless/base-debian11
 COPY --from=build /go/bin/provider /
-COPY --from=build /root/.reference-provider* /root/.reference-provider
+COPY --from=build /root/.index-provider* /root/.index-provider
 ENTRYPOINT ["/provider"]
 CMD ["daemon"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-BIN := indexer-reference-provider
+BIN := index-provider
 
 .PHONY: all build clean test
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 Indexer Reference Provider :loudspeaker:
 =======================
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](https://protocol.ai)
-[![Go Reference](https://pkg.go.dev/badge/github.com/filecoin-project/indexer-reference-provider.svg)](https://pkg.go.dev/github.com/filecoin-project/indexer-reference-provider)
-[![Coverage Status](https://codecov.io/gh/filecoin-project/indexer-reference-provider/branch/main/graph/badge.svg)](https://codecov.io/gh/filecoin-project/indexer-reference-provider/branch/main)
+[![Go Reference](https://pkg.go.dev/badge/github.com/filecoin-project/index-provider.svg)](https://pkg.go.dev/github.com/filecoin-project/index-provider)
+[![Coverage Status](https://codecov.io/gh/filecoin-project/index-provider/branch/main/graph/badge.svg)](https://codecov.io/gh/filecoin-project/index-provider/branch/main)
 
-> A reference implementation of indexer data provider
+> A reference implementation of index data provider
 
 This repo provides a reference data provider implementation that can be used to advertise content to
 indexer nodes and serve retreival requests over graphsync.
@@ -22,13 +22,13 @@ Prerequisite:
 To use the provider as a Go library, execute:
 
 ```shell
-go get github.com/filecoin-project/indexer-reference-provider
+go get github.com/filecoin-project/index-provider
 ```
 
 To install the latest runnable version of the provider service, execute:
 
 ```shell
-go install github.com/filecoin-project/indexer-reference-provider/cmd/provider@latest
+go install github.com/filecoin-project/index-provider/cmd/provider@latest
 ```
 
 ## Running Provider Service
@@ -41,7 +41,7 @@ provider init
 
 Initialization generates a default configuration for the provider instance along with a randomly
 generated identity keypair. The configuration is stored at user home
-under `.reference-provider/config` in JSON format. The root configuration path can be overridden by
+under `.index-provider/config` in JSON format. The root configuration path can be overridden by
 setting the `PROVIDER_PATH` environment variable
 
 Once initialized, start the service daemon by executing:

--- a/config/config.go
+++ b/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 
 const (
 	// DefaultPathName is the default config dir name
-	DefaultPathName = ".reference-provider"
+	DefaultPathName = ".index-provider"
 	// DefaultPathRoot is the path to the default config dir location.
 	DefaultPathRoot = "~/" + DefaultPathName
 	// DefaultConfigFile is the filename of the configuration file


### PR DESCRIPTION
This makes the binary executable and default repo directory names match the project name, making them more easily identified.

Import path names will be changed in a separate PR.