### PR TITLE
Fix Makefile bin target to use correct modfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 BIN := index-provider
+CMD_SUBDIR := "cmd"
 
 .PHONY: all build clean test
 
@@ -10,7 +11,7 @@ docker: Dockerfile clean
 	docker build . --force-rm -f Dockerfile -t indexer-reference-provider:$(shell git rev-parse --short HEAD)
 
 $(BIN): vet test
-	go build -o $@ cmd/provider/*.go
+	go build -modfile $(CMD_SUBDIR)/go.mod -o $@ $(CMD_SUBDIR)/provider/*.go
 
 lint:
 	golangci-lint run


### PR DESCRIPTION
This is necessary to build using `make` now that `cmd` is a separate module.