### PR TITLE
Recognize absolute paths in config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -3,14 +3,13 @@ package config
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/mitchellh/go-homedir"
 )
 
-// Config is used to load config files
+// Config is used to load config files.
 type Config struct {
 	Identity       Identity
 	Datastore      Datastore
@@ -21,36 +20,40 @@ type Config struct {
 }
 
 const (
-	// DefaultPathName is the default config dir name
+	// DefaultPathName is the default config dir name.
 	DefaultPathName = ".index-provider"
 	// DefaultPathRoot is the path to the default config dir location.
 	DefaultPathRoot = "~/" + DefaultPathName
-	// DefaultConfigFile is the filename of the configuration file
+	// DefaultConfigFile is the filename of the configuration file.
 	DefaultConfigFile = "config"
 	// EnvDir is the environment variable used to change the path root.
 	EnvDir = "PROVIDER_PATH"
 )
 
 var (
-	ErrInitialized    = errors.New("already initialized")
+	ErrInitialized    = errors.New("configuration file already exists")
 	ErrNotInitialized = errors.New("not initialized")
 )
 
 // Filename returns the configuration file path given a configuration root
-// directory. If the configuration root directory is empty, use the default one
+// directory. If the configuration root directory is empty, use the default.
 func Filename(configRoot string) (string, error) {
 	return Path(configRoot, DefaultConfigFile)
 }
 
-// Marshal configuration with JSON
+// Marshal configuration with JSON.
 func Marshal(value interface{}) ([]byte, error) {
-	// need to prettyprint, hence MarshalIndent, instead of Encoder
+	// need to prettyprint, hence MarshalIndent, instead of Encoder.
 	return json.MarshalIndent(value, "", "  ")
 }
 
 // Path returns the config file path relative to the configuration root. If an
-// empty string is provided for `configRoot`, the default root is used.
+// empty string is provided for `configRoot`, the default root is used. If
+// configFile is an absolute path, then configRoot is ignored.
 func Path(configRoot, configFile string) (string, error) {
+	if filepath.IsAbs(configFile) {
+		return filepath.Clean(configFile), nil
+	}
 	if configRoot == "" {
 		var err error
 		configRoot, err = PathRoot()
@@ -61,7 +64,7 @@ func Path(configRoot, configFile string) (string, error) {
 	return filepath.Join(configRoot, configFile), nil
 }
 
-// PathRoot returns the default configuration root directory
+// PathRoot returns the default configuration root directory.
 func PathRoot() (string, error) {
 	dir := os.Getenv(EnvDir)
 	if dir != "" {
@@ -70,7 +73,7 @@ func PathRoot() (string, error) {
 	return homedir.Expand(DefaultPathRoot)
 }
 
-// Load reads the json-serialized config at the specified path
+// Load reads the json-serialized config at the specified path.
 func Load(filePath string) (*Config, error) {
 	var err error
 	if filePath == "" {
@@ -91,7 +94,7 @@ func Load(filePath string) (*Config, error) {
 
 	var cfg Config
 	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
-		return nil, fmt.Errorf("failure to decode config: %s", err)
+		return nil, err
 	}
 
 	// Replace any zero-values with defaults.
@@ -100,7 +103,7 @@ func Load(filePath string) (*Config, error) {
 	return &cfg, nil
 }
 
-// Save writes the json-serialized config to the specified path
+// Save writes the json-serialized config to the specified path.
 func (c *Config) Save(filePath string) error {
 	var err error
 	if filePath == "" {
@@ -110,7 +113,7 @@ func (c *Config) Save(filePath string) error {
 		}
 	}
 
-	err = os.MkdirAll(filepath.Dir(filePath), 0o755)
+	err = os.MkdirAll(filepath.Dir(filePath), 0755)
 	if err != nil {
 		return err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,14 +2,19 @@ package config
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
 func TestPath(t *testing.T) {
-	const (
-		dir    = "vstore"
+	const dir = "vstore"
+
+	var absdir string
+	if runtime.GOOS == "windows" {
+		absdir = "c:\\tmp\vstore"
+	} else {
 		absdir = "/tmp/vstore"
-	)
+	}
 
 	path, err := Path("", dir)
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPath(t *testing.T) {
+	const (
+		dir    = "vstore"
+		absdir = "/tmp/vstore"
+	)
+
+	path, err := Path("", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	configRoot, err := PathRoot()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if path != filepath.Join(configRoot, dir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+
+	path, err = Path("altroot", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Join("altroot", dir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+
+	path, err = Path("altroot", absdir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != filepath.Clean(absdir) {
+		t.Fatalf("wrong path %s:", path)
+	}
+}


### PR DESCRIPTION
This is useful when specifying a path for the datastore that is outside of the config root.