### PR TITLE
Do not close the wrapped datastore used for caching

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -206,6 +206,11 @@ func daemonCommand(cctx *cli.Context) error {
 		finalErr = ErrDaemonStop
 	}
 
+	if err = ds.Close(); err != nil {
+		log.Errorf("Error closing provider datastore: %s", err)
+		finalErr = ErrDaemonStop
+	}
+
 	if err := os.RemoveAll(tmpDir); err != nil {
 		log.Errorf("Error cleaning up temporary files: %s", err)
 		finalErr = ErrCleanupFiles


### PR DESCRIPTION
The index provider engine as well as its internal components, like
`dsCache` take an existing datastore instance and reuse it internally.
`dsChace` implements the `datastore.Datastore` interface by wapping the
existing instance. Since the instance is instantiated externally, it
should not be closed off by the provider `Engine` nor `dsChache`.

Instead, delegate the management of the datastore lifecycle to where it
is instantiated, i.e. the `daemon` command.