### PR TITLE
ContextID should be only sha256 hash

### DIFF
--- a/cmd/provider/find.go
+++ b/cmd/provider/find.go
@@ -54,7 +54,10 @@ func findCommand(cctx *cli.Context) error {
 	for i := range resp.MultihashResults {
 		fmt.Println("   Multihash:", resp.MultihashResults[i].Multihash.B58String(), "==>")
 		for _, pr := range resp.MultihashResults[i].ProviderResults {
-			fmt.Println("       Provider:", pr.Provider, "Proto:", pr.Metadata.ProtocolID, "Data:", string(pr.Metadata.Data))
+			fmt.Println("       Provider:", pr.Provider)
+			fmt.Println("       ContextID:", string(pr.ContextID))
+			fmt.Println("       Proto:", pr.Metadata.ProtocolID)
+			fmt.Println("       Metadata:", string(pr.Metadata.Data))
 		}
 	}
 

--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -47,7 +47,9 @@ func beforeImportCar(cctx *cli.Context) error {
 		}
 		importCarKey = decoded
 	} else {
-		importCarKey = sha256.New().Sum([]byte(carPathFlagValue))
+		h := sha256.New()
+		h.Write([]byte(carPathFlagValue))
+		importCarKey = h.Sum(nil)
 	}
 	if cctx.IsSet(metadataFlag.Name) {
 		decoded, err := base64.StdEncoding.DecodeString(metadataFlagValue)


### PR DESCRIPTION
When importing a car file, the context ID was being computed incorrectly and was including the entire car file path in the context ID.  This PR fixes this so that only the sha256 hash is used to create the context ID.

For a demonstration of the wrong vs. correct calculation, see https://go.dev/play/p/cak7EJH1Y_y 

Find command also has clearer output.