### PR TITLE
Refactor config for easier instantiation with default values

### DIFF
--- a/config/adminserver.go
+++ b/config/adminserver.go
@@ -20,6 +20,15 @@ type AdminServer struct {
 	WriteTimeout    Duration
 }
 
+// NewAdminServer instantiates a new AdminServer config with default values.
+func NewAdminServer() AdminServer {
+	return AdminServer{
+		ListenMultiaddr: defaultAdminServerAddr,
+		ReadTimeout:     defaultReadTimeout,
+		WriteTimeout:    defaultWriteTimeout,
+	}
+}
+
 func (as *AdminServer) ListenNetAddr() (string, error) {
 	maddr, err := multiaddr.NewMultiaddr(as.ListenMultiaddr)
 	if err != nil {

--- a/config/bootstrap.go
+++ b/config/bootstrap.go
@@ -3,20 +3,17 @@ package config
 import (
 	"errors"
 	"fmt"
-	"time"
-
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 )
 
-const (
-	defaultMinimumPeers     = 1
-	defaultBootstrapPeriod  = 30 * time.Second
-	defaulConnectionTimeout = defaultBootstrapPeriod / 3
-)
+const defaultMinimumPeers = 1
 
 // defaultBootstrapAddresses are the hardcoded bootstrap addresses.
 var defaultBootstrapAddresses = []string{}
+
+// ErrInvalidPeerAddr signals an address is not a valid peer address.
+var ErrInvalidPeerAddr = errors.New("invalid peer address")
 
 type Bootstrap struct {
 	// Peers is the local nodes's bootstrap peer addresses
@@ -27,8 +24,13 @@ type Bootstrap struct {
 	MinimumPeers int
 }
 
-// ErrInvalidPeerAddr signals an address is not a valid peer address.
-var ErrInvalidPeerAddr = errors.New("invalid peer address")
+// NewBootstrap instantiates a new Bootstrap config with default values.
+func NewBootstrap() Bootstrap {
+	return Bootstrap{
+		Peers:        defaultBootstrapPeers(),
+		MinimumPeers: defaultMinimumPeers,
+	}
+}
 
 // PeerAddrs returns the bootstrap peers as a list of AddrInfo.
 func (b Bootstrap) PeerAddrs() ([]peer.AddrInfo, error) {

--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,7 @@ func Load(filePath string) (*Config, error) {
 	}
 
 	// Replace any zero-values with defaults.
-	cfg.Ingest.defaults()
+	cfg.Ingest.overrideUnsetToDefaults()
 
 	return &cfg, nil
 }

--- a/config/datastore.go
+++ b/config/datastore.go
@@ -12,3 +12,11 @@ type Datastore struct {
 	// Dir is the directory within the config root where the datastore is kept
 	Dir string
 }
+
+// NewDatastore instantiates a new Datastore config with default values.
+func NewDatastore() Datastore {
+	return Datastore{
+		Type: defaultDatastoreType,
+		Dir:  defaultDatastoreDir,
+	}
+}

--- a/config/identity.go
+++ b/config/identity.go
@@ -8,12 +8,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
-const (
-	IdentityTag     = "Identity"
-	PrivKeyTag      = "PrivKey"
-	PrivKeySelector = IdentityTag + "." + PrivKeyTag
-)
-
 // Identity tracks the configuration of the local node's identity.
 type Identity struct {
 	PeerID  string

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -21,8 +21,17 @@ type Ingest struct {
 	PurgeLinkCache bool
 }
 
-// defaults replaces zero-values in the config with default values.
-func (cfg *Ingest) defaults() {
+// NewIngest instantiates a new Ingest configuration with default values.
+func NewIngest() Ingest {
+	return Ingest{
+		LinkCacheSize:   defaultLinkCacheSize,
+		LinkedChunkSize: defaultLinkedChunkSize,
+		PubSubTopic:     defaultPubSubTopic,
+	}
+}
+
+// overrideUnsetToDefaults replaces zero-values in the config with default values.
+func (cfg *Ingest) overrideUnsetToDefaults() {
 	if cfg.LinkCacheSize == 0 {
 		cfg.LinkCacheSize = defaultLinkCacheSize
 	}

--- a/config/init.go
+++ b/config/init.go
@@ -20,28 +20,12 @@ func Init(out io.Writer) (*Config, error) {
 
 func InitWithIdentity(identity Identity) (*Config, error) {
 	return &Config{
-		Identity: identity,
-		Bootstrap: Bootstrap{
-			Peers:        defaultBootstrapPeers(),
-			MinimumPeers: defaultMinimumPeers,
-		},
-		Datastore: Datastore{
-			Type: defaultDatastoreType,
-			Dir:  defaultDatastoreDir,
-		},
-		Ingest: Ingest{
-			LinkCacheSize:   defaultLinkCacheSize,
-			LinkedChunkSize: defaultLinkedChunkSize,
-			PubSubTopic:     defaultPubSubTopic,
-		},
-		ProviderServer: ProviderServer{
-			ListenMultiaddr: defaultNodeMultiaddr,
-		},
-		AdminServer: AdminServer{
-			ListenMultiaddr: defaultAdminServerAddr,
-			ReadTimeout:     defaultReadTimeout,
-			WriteTimeout:    defaultWriteTimeout,
-		},
+		Identity:       identity,
+		Bootstrap:      NewBootstrap(),
+		Datastore:      NewDatastore(),
+		Ingest:         NewIngest(),
+		ProviderServer: NewProviderServer(),
+		AdminServer:    NewAdminServer(),
 	}, nil
 }
 

--- a/config/providerserver.go
+++ b/config/providerserver.go
@@ -1,12 +1,16 @@
 package config
 
-const (
-	defaultNodeMultiaddr = "/ip4/0.0.0.0/tcp/3103"
-)
-
 type ProviderServer struct {
 	// ListenMultiaddr is the multiaddr string for the node's listen address
 	ListenMultiaddr string
-	// RetrievalMultiaddrs are the addresses to advertise for data retrieval
+	// RetrievalMultiaddrs are the addresses to advertise for data retrieval.
+	// Defaults to the provider's libp2p host listen addresses.
 	RetrievalMultiaddrs []string
+}
+
+// NewProviderServer instantiates a new ProviderServer config with default values.
+func NewProviderServer() ProviderServer {
+	return ProviderServer{
+		ListenMultiaddr: "/ip4/0.0.0.0/tcp/3103",
+	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -71,10 +71,10 @@ var _ provider.Interface = (*Engine)(nil)
 
 // New creates a new engine.  The context is only used for canceling the call
 // to New.
-func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.Host, ds datastore.Batching, addrs []string) (*Engine, error) {
-	if len(addrs) == 0 {
-		addrs = []string{h.Addrs()[0].String()}
-		log.Infof("Retrieval address not configured, using %s", addrs[0])
+func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.Host, ds datastore.Batching, retAddrs []string) (*Engine, error) {
+	if len(retAddrs) == 0 {
+		retAddrs = []string{h.Addrs()[0].String()}
+		log.Infof("Retrieval address not configured, using %s", retAddrs[0])
 	}
 
 	// TODO(security): We should not keep the privkey decoded here.
@@ -90,7 +90,7 @@ func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.
 		purgeLinkCache:  ingestCfg.PurgeLinkCache,
 		linkCacheSize:   ingestCfg.LinkCacheSize,
 
-		addrs: addrs,
+		addrs: retAddrs,
 	}
 
 	e.cachelsys = e.cacheLinkSystem()


### PR DESCRIPTION
Add `New*` constructor for each of the sub config types with default
values.

Fixed #108