### PR TITLE
Generate valid removal advertisements

### DIFF
--- a/cmd/provider/find.go
+++ b/cmd/provider/find.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	httpfinderclient "github.com/filecoin-project/storetheindex/api/v0/finder/client/http"
@@ -52,12 +53,12 @@ func findCommand(cctx *cli.Context) error {
 
 	fmt.Println("Content providers:")
 	for i := range resp.MultihashResults {
-		fmt.Println("   Multihash:", resp.MultihashResults[i].Multihash.B58String(), "==>")
+		fmt.Println("   Multihash:", resp.MultihashResults[i].Multihash.B58String())
 		for _, pr := range resp.MultihashResults[i].ProviderResults {
 			fmt.Println("       Provider:", pr.Provider)
-			fmt.Println("       ContextID:", string(pr.ContextID))
+			fmt.Println("       ContextID:", base64.StdEncoding.EncodeToString(pr.ContextID))
 			fmt.Println("       Proto:", pr.Metadata.ProtocolID)
-			fmt.Println("       Metadata:", string(pr.Metadata.Data))
+			fmt.Println("       Metadata:", base64.StdEncoding.EncodeToString(pr.Metadata.Data))
 		}
 	}
 

--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -14,9 +14,6 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-// TODO: This should change to a code that indicates graphsync.
-const providerProtocolID = 0x300001
-
 var ImportCmd = &cli.Command{
 	Name:        "import",
 	Aliases:     []string{"i"},
@@ -35,7 +32,7 @@ var (
 		Action:  doImportCar,
 	}
 	metadata = stiapi.Metadata{
-		ProtocolID: providerProtocolID,
+		ProtocolID: cardatatransfer.ContextIDCodec,
 	}
 )
 
@@ -86,12 +83,14 @@ func doImportCar(cctx *cli.Context) error {
 	log.Infof("imported car successfully")
 	var res adminserver.ImportCarRes
 	if _, err := res.ReadFrom(resp.Body); err != nil {
-		return fmt.Errorf("received OK response from server but cannot decode response body. %v", err)
+		return fmt.Errorf("received ok response from server but cannot decode response body. %v", err)
 	}
 	var b bytes.Buffer
 	b.WriteString("Successfully imported CAR.\n")
 	b.WriteString("\t Advertisement ID: ")
 	b.WriteString(res.AdvId.String())
+	b.WriteString("\n\t Context ID: ")
+	b.WriteString(base64.StdEncoding.EncodeToString(importCarKey))
 	b.WriteString("\n")
 	_, err = cctx.App.Writer.Write(b.Bytes())
 	return err

--- a/cmd/provider/remove.go
+++ b/cmd/provider/remove.go
@@ -44,25 +44,25 @@ specified, they key is simply calculated as the SHA_256 hash of the given path.`
 )
 
 func beforeRemoveCar(cctx *cli.Context) error {
-	keyFlagSet := cctx.IsSet(keyFlag.Name)
-	carPathFlagSet := cctx.IsSet(carPathFlag.Name)
-
-	if keyFlagSet && carPathFlagSet {
-		return fmt.Errorf("only one of %s or %s must be set", keyFlag.Name, carPathFlag.Name)
-	}
-	if !keyFlagSet && !carPathFlagSet {
-		return fmt.Errorf("either %s or %s must be set", keyFlag.Name, carPathFlag.Name)
-	}
-
-	if keyFlagSet {
-		decoded, err := base64.StdEncoding.DecodeString(keyFlagValue)
-		if err != nil {
-			return errors.New("key is not a valid base64 encoded string")
+	if !cctx.IsSet(keyFlag.Name) {
+		if !cctx.IsSet(optionalCarPathFlag.Name) {
+			return fmt.Errorf("either %s or %s must be set", keyFlag.Name, optionalCarPathFlag.Name)
 		}
-		removeCarKey = decoded
-	} else {
-		removeCarKey = sha256.New().Sum([]byte(carPathFlagValue))
+		fmt.Println("carPathFlagValue:", optionalCarPathFlagValue)
+		h := sha256.New()
+		h.Write([]byte(optionalCarPathFlagValue))
+		removeCarKey = h.Sum(nil)
+		return nil
 	}
+
+	if cctx.IsSet(optionalCarPathFlag.Name) {
+		return fmt.Errorf("only one of %s or %s must be set", keyFlag.Name, optionalCarPathFlag.Name)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(keyFlagValue)
+	if err != nil {
+		return errors.New("key is not a valid base64 encoded string")
+	}
+	removeCarKey = decoded
 	return nil
 }
 
@@ -79,15 +79,16 @@ func doRemoveCar(cctx *cli.Context) error {
 		return errFromHttpResp(resp)
 	}
 
-	log.Info("removed car successfully", "key", removeCarKey)
 	var res adminserver.RemoveCarRes
 	if _, err := res.ReadFrom(resp.Body); err != nil {
-		return fmt.Errorf("received OK response from server but cannot decode response body. %v", err)
+		return fmt.Errorf("received ok response from server but cannot decode response body. %v", err)
 	}
 	var b bytes.Buffer
 	b.WriteString("Successfully removed CAR.\n")
 	b.WriteString("\t Advertisement ID: ")
 	b.WriteString(res.AdvId.String())
+	b.WriteString("\n\t Context ID: ")
+	b.WriteString(base64.StdEncoding.EncodeToString(removeCarKey))
 	b.WriteString("\n")
 	_, err = cctx.App.Writer.Write(b.Bytes())
 	return err

--- a/cmd/provider/remove.go
+++ b/cmd/provider/remove.go
@@ -48,7 +48,6 @@ func beforeRemoveCar(cctx *cli.Context) error {
 		if !cctx.IsSet(optionalCarPathFlag.Name) {
 			return fmt.Errorf("either %s or %s must be set", keyFlag.Name, optionalCarPathFlag.Name)
 		}
-		fmt.Println("carPathFlagValue:", optionalCarPathFlagValue)
 		h := sha256.New()
 		h.Write([]byte(optionalCarPathFlagValue))
 		removeCarKey = h.Sum(nil)

--- a/server/admin/http/removecar_handler_test.go
+++ b/server/admin/http/removecar_handler_test.go
@@ -84,7 +84,7 @@ func Test_removeCarHandlerFail(t *testing.T) {
 
 	respBytes, err := ioutil.ReadAll(rr.Body)
 	require.NoError(t, err)
-	require.Equal(t, "failed to remove CAR: fish\n", string(respBytes))
+	require.Equal(t, "error removing car: fish\n", string(respBytes))
 }
 
 func Test_removeCarHandler_NonExistingCarIsNotFound(t *testing.T) {


### PR DESCRIPTION
Advertisements require valid metadata, even though metadata is not used for index removal.  This change creates a removal advertisement with valid, but empty, metadata.

Additional changes:
- Fix bad contextID creation in remove command
- Improve output of find, import, and remove commands
- Improve log messages: readable contextID, structured logging

Fixes issue #121