### PR TITLE
Re-enable flaky tests and remove `time.Sleep` s using event tracer

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -76,6 +76,10 @@ type Engine struct {
 	// cb is the callback used in the linkSystem
 	cb   provider.Callback
 	cblk sync.Mutex
+
+	// dtsyncOptions specifies the options used to instantiate legs dtsync.publisher on Engine.Start.
+	// This field is used for testing purposes only to set low lever pubsub.Topic options.
+	dtsyncOptions []dtsync.Option
 }
 
 var _ provider.Interface = (*Engine)(nil)
@@ -182,7 +186,8 @@ func (e *Engine) Start(ctx context.Context) error {
 		}
 		e.publisher, err = httpsync.NewPublisher(addr, e.lsys, e.host.ID(), e.privKey)
 	} else {
-		e.publisher, err = dtsync.NewPublisherFromExisting(e.dataTransfer, e.host, e.pubSubTopic, e.lsys, dtsync.WithExtraData(e.extraGossipData))
+		e.dtsyncOptions = append(e.dtsyncOptions, dtsync.WithExtraData(e.extraGossipData))
+		e.publisher, err = dtsync.NewPublisherFromExisting(e.dataTransfer, e.host, e.pubSubTopic, e.lsys, e.dtsyncOptions...)
 	}
 	if err != nil {
 		return fmt.Errorf("cannot initialize publisher: %s", err)

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -30,7 +30,7 @@ func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {
 	cfg := config.NewIngest()
 	cfg.LinkedChunkSize = 2
 	cfg.LinkCacheSize = 1
-	subject := mkEngineWithConfig(t, cfg)
+	subject := mkEngineWithConfig(t, cfg, nil)
 
 	ad1CtxID := []byte("first")
 	ad1MhCount := 12

--- a/engine/pubsubtracer_test.go
+++ b/engine/pubsubtracer_test.go
@@ -1,0 +1,78 @@
+package engine
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/libp2p/go-libp2p-core/peer"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
+)
+
+var _ pubsub.EventTracer = (*testPubSubTracer)(nil)
+
+// testPubSubTracer is a pubsub.EventTracer that allows the tracer to expect certain events, useful
+// for testing.
+type testPubSubTracer struct {
+	m      sync.Mutex
+	tracer func(evt *pubsubpb.TraceEvent)
+}
+
+func (tpst *testPubSubTracer) Trace(evt *pubsubpb.TraceEvent) {
+	tpst.m.Lock()
+	defer tpst.m.Unlock()
+	if tpst.tracer != nil {
+		tpst.tracer(evt)
+	}
+}
+
+// requireDeliverMessageEventually checks that a message is delivered on the given topic from the given peer ID within a timeout.
+func (tpst *testPubSubTracer) requireDeliverMessageEventually(from peer.ID, topic string, timeout time.Duration) <-chan bool {
+	return tpst.requireOnceEventually(func(evt *pubsubpb.TraceEvent) bool {
+		return pubsubpb.TraceEvent_DELIVER_MESSAGE == evt.GetType() &&
+			from == peer.ID(evt.GetDeliverMessage().GetReceivedFrom()) &&
+			topic == evt.GetDeliverMessage().GetTopic()
+	}, timeout)
+}
+
+// requireOnceEventually applies the given check function to the trace events until one one of them
+// passes the check or the timeout occurs.
+// This function returns a channel that indicates whether the check passed for at least one of the
+// trace events within timeout.
+func (tpst *testPubSubTracer) requireOnceEventually(check func(evt *pubsubpb.TraceEvent) bool, timeout time.Duration) <-chan bool {
+	// Use two separate channels, one for signalling the final result to the caller and
+	// one for signalling that the check has passed.
+	// The channels are separate so that we can guarantee that channels are written to exactly once
+	// by the same writer and closed when written to.
+	result := make(chan bool, 1)
+	passed := make(chan bool, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	go func() {
+		defer close(result)
+		// Await until either timeout occurs or check passes.
+		select {
+		case <-ctx.Done():
+			result <- false
+		case <-passed:
+			result <- true
+			cancel()
+		}
+
+		// Clear tracer when done.
+		tpst.m.Lock()
+		defer tpst.m.Unlock()
+		tpst.tracer = nil
+	}()
+
+	tpst.m.Lock()
+	defer tpst.m.Unlock()
+	tpst.tracer = func(evt *pubsubpb.TraceEvent) {
+		pass := check(evt)
+		if pass {
+			passed <- pass
+			close(passed)
+		}
+	}
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -22,11 +22,13 @@ require (
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/libp2p/go-libp2p v0.18.0-rc1
 	github.com/libp2p/go-libp2p-core v0.14.0
+	github.com/libp2p/go-libp2p-pubsub v0.6.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multicodec v0.4.0
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/stretchr/testify v1.7.0
 	github.com/whyrusleeping/cbor-gen v0.0.0-20211110122933-f57984553008
+	golang.org/x/crypto v0.0.0-20211117183948-ae814b36b871
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )


### PR DESCRIPTION
Now that go-legs is heavily refactored, re-enable the flaky tests and
remove explicit `time.Sleep` calls in the tests. This is so that we can
check if tests remain flaky and if so how to fix them so that they are
not.

Implement a bespoke pubsub event tracer that allows tests to observe and
wait for pubsub events before proceeding with other assertions.

Refactor assertions to reduce duplicate code across engine tests.

 Fixes #12