### PR TITLE
Set ingest config defaults on engine construction

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -98,7 +98,7 @@ func Load(filePath string) (*Config, error) {
 	}
 
 	// Replace any zero-values with defaults.
-	cfg.Ingest.overrideUnsetToDefaults()
+	cfg.Ingest.OverrideUnsetToDefaults()
 
 	return &cfg, nil
 }

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -30,8 +30,8 @@ func NewIngest() Ingest {
 	}
 }
 
-// overrideUnsetToDefaults replaces zero-values in the config with default values.
-func (cfg *Ingest) overrideUnsetToDefaults() {
+// OverrideUnsetToDefaults replaces zero-values in the config with default values.
+func (cfg *Ingest) OverrideUnsetToDefaults() {
 	if cfg.LinkCacheSize == 0 {
 		cfg.LinkCacheSize = defaultLinkCacheSize
 	}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -99,6 +99,8 @@ func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.
 		log.Infof("Retrieval address not configured, using %s", retAddrs[0])
 	}
 
+	ingestCfg.OverrideUnsetToDefaults()
+
 	// TODO(security): We should not keep the privkey decoded here.
 	// We should probably unlock it and lock it every time we need it.
 	// Once we start encrypting the key locally.

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -434,3 +434,12 @@ func skipFlaky(t *testing.T) {
 		t.Skip("skipping test since it is flaky on the CI. See https://github.com/filecoin-project/index-provider/issues/12")
 	}
 }
+
+func Test_EmptyConfigSetsDefaults(t *testing.T) {
+	engine, err := New(config.Ingest{}, nil, nil, mkTestHost(t), nil, nil)
+	require.NoError(t, err)
+	require.True(t, engine.linkedChunkSize > 0)
+	require.True(t, engine.linkCacheSize > 0)
+	require.True(t, engine.pubSubTopic != "")
+	require.True(t, engine.pubSubTopic != "")
+}


### PR DESCRIPTION
When engine is constructed assert that the default configs are set in
ingest config before engine is constructed.

Fixes #134