### PR TITLE
Support http publisher

### DIFF
--- a/config/httppublisher.go
+++ b/config/httppublisher.go
@@ -6,16 +6,12 @@ import (
 )
 
 type HttpPublisher struct {
-	// Enabled will enable only the http implementation of legs.Publisher. All
-	// other implementations will be disabled. (e.g. dtsync publisher)
-	Enabled         bool
 	ListenMultiaddr string
 }
 
 // NewHttpPublisher instantiates a new config with default values.
 func NewHttpPublisher() HttpPublisher {
 	return HttpPublisher{
-		Enabled:         false,
 		ListenMultiaddr: "/ip4/0.0.0.0/tcp/3104/http",
 	}
 }

--- a/config/httppublisher.go
+++ b/config/httppublisher.go
@@ -5,20 +5,22 @@ import (
 	manet "github.com/multiformats/go-multiaddr/net"
 )
 
-type HttpServer struct {
+type HttpPublisher struct {
+	// Enabled will enable only the http implementation of legs.Publisher. All
+	// other implementations will be disabled. (e.g. dtsync publisher)
 	Enabled         bool
 	ListenMultiaddr string
 }
 
-// NewHttpServer instantiates a new config with default values.
-func NewHttpServer() HttpServer {
-	return HttpServer{
+// NewHttpPublisher instantiates a new config with default values.
+func NewHttpPublisher() HttpPublisher {
+	return HttpPublisher{
 		Enabled:         false,
 		ListenMultiaddr: "/ip4/0.0.0.0/tcp/3104/http",
 	}
 }
 
-func (hs *HttpServer) ListenNetAddr() (string, error) {
+func (hs *HttpPublisher) ListenNetAddr() (string, error) {
 	maddr, err := multiaddr.NewMultiaddr(hs.ListenMultiaddr)
 	if err != nil {
 		return "", err

--- a/config/httpserver.go
+++ b/config/httpserver.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+type HttpServer struct {
+	Enabled         bool
+	ListenMultiaddr string
+}
+
+// NewHttpServer instantiates a new config with default values.
+func NewHttpServer() HttpServer {
+	return HttpServer{
+		Enabled:         false,
+		ListenMultiaddr: "/ip4/0.0.0.0/tcp/3104/http",
+	}
+}
+
+func (hs *HttpServer) ListenNetAddr() (string, error) {
+	maddr, err := multiaddr.NewMultiaddr(hs.ListenMultiaddr)
+	if err != nil {
+		return "", err
+	}
+	httpMultiaddr, _ := multiaddr.NewMultiaddr("/http")
+	maddr = maddr.Decapsulate(httpMultiaddr)
+
+	netAddr, err := manet.ToNetAddr(maddr)
+	if err != nil {
+		return "", err
+	}
+	return netAddr.String(), nil
+}

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -8,6 +8,13 @@ const (
 	defaultPubSubTopic     = "indexer/ingest"
 )
 
+type PublisherKind string
+
+const (
+	DTSyncPublisherKind PublisherKind = "dtsync"
+	HttpPublisherKind   PublisherKind = "http"
+)
+
 // Ingest configures settings related to the ingestion protocol.
 type Ingest struct {
 	// LinkCacheSize is the maximum number of links that cash can store before
@@ -24,9 +31,11 @@ type Ingest struct {
 	// PurgeLinkCache tells whether to purge the link cache on daemon startup.
 	PurgeLinkCache bool
 
-	// HttpPublisher configures the go-legs httpsync publisher. If it is enabled,
-	// only the httpsync publisher will be used.
+	// HttpPublisher configures the go-legs httpsync publisher.
 	HttpPublisher HttpPublisher
+
+	// PublisherKind specifies which legs.Publisher implementation to use.
+	PublisherKind PublisherKind
 }
 
 // NewIngest instantiates a new Ingest configuration with default values.
@@ -36,6 +45,7 @@ func NewIngest() Ingest {
 		LinkedChunkSize: defaultLinkedChunkSize,
 		PubSubTopic:     defaultPubSubTopic,
 		HttpPublisher:   NewHttpPublisher(),
+		PublisherKind:   DTSyncPublisherKind,
 	}
 }
 

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -23,6 +23,9 @@ type Ingest struct {
 	PubSubTopic string
 	// PurgeLinkCache tells whether to purge the link cache on daemon startup.
 	PurgeLinkCache bool
+
+	// HttpServer configures the go-legs httpsync publisher
+	HttpServer HttpServer
 }
 
 // NewIngest instantiates a new Ingest configuration with default values.
@@ -31,6 +34,7 @@ func NewIngest() Ingest {
 		LinkCacheSize:   defaultLinkCacheSize,
 		LinkedChunkSize: defaultLinkedChunkSize,
 		PubSubTopic:     defaultPubSubTopic,
+		HttpServer:      NewHttpServer(),
 	}
 }
 

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -24,8 +24,9 @@ type Ingest struct {
 	// PurgeLinkCache tells whether to purge the link cache on daemon startup.
 	PurgeLinkCache bool
 
-	// HttpServer configures the go-legs httpsync publisher
-	HttpServer HttpServer
+	// HttpPublisher configures the go-legs httpsync publisher. If it is enabled,
+	// only the httpsync publisher will be used.
+	HttpPublisher HttpPublisher
 }
 
 // NewIngest instantiates a new Ingest configuration with default values.
@@ -34,7 +35,7 @@ func NewIngest() Ingest {
 		LinkCacheSize:   defaultLinkCacheSize,
 		LinkedChunkSize: defaultLinkedChunkSize,
 		PubSubTopic:     defaultPubSubTopic,
-		HttpServer:      NewHttpServer(),
+		HttpPublisher:   NewHttpPublisher(),
 	}
 }
 

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -53,7 +53,7 @@ var testCases = []testCase{
 		serverConfigOpts: []func(*config.Ingest){
 			func(c *config.Ingest) {
 				httpPublisherCfg := config.NewHttpPublisher()
-				httpPublisherCfg.Enabled = true
+				c.PublisherKind = config.HttpPublisherKind
 				c.HttpPublisher = httpPublisherCfg
 			},
 		},
@@ -270,7 +270,7 @@ func newTestServer(t *testing.T, ctx context.Context, cfgOpts ...func(*config.In
 	}
 
 	var publisherAddr multiaddr.Multiaddr
-	if ingestCfg.HttpPublisher.Enabled {
+	if ingestCfg.PublisherKind == config.HttpPublisherKind {
 		port := findOpenPort(t)
 		publisherAddr, err = multiaddr.NewMultiaddr(ingestCfg.HttpPublisher.ListenMultiaddr)
 		require.NoError(t, err)

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -52,9 +52,9 @@ var testCases = []testCase{
 		name: "HTTP Publisher",
 		serverConfigOpts: []func(*config.Ingest){
 			func(c *config.Ingest) {
-				httpPublisherCfg := config.NewHttpServer()
+				httpPublisherCfg := config.NewHttpPublisher()
 				httpPublisherCfg.Enabled = true
-				c.HttpServer = httpPublisherCfg
+				c.HttpPublisher = httpPublisherCfg
 			},
 		},
 	},
@@ -270,9 +270,9 @@ func newTestServer(t *testing.T, ctx context.Context, cfgOpts ...func(*config.In
 	}
 
 	var publisherAddr multiaddr.Multiaddr
-	if ingestCfg.HttpServer.Enabled {
+	if ingestCfg.HttpPublisher.Enabled {
 		port := findOpenPort(t)
-		publisherAddr, err = multiaddr.NewMultiaddr(ingestCfg.HttpServer.ListenMultiaddr)
+		publisherAddr, err = multiaddr.NewMultiaddr(ingestCfg.HttpPublisher.ListenMultiaddr)
 		require.NoError(t, err)
 
 		// Replace the default port with a port we know is open so that tests can
@@ -285,7 +285,7 @@ func newTestServer(t *testing.T, ctx context.Context, cfgOpts ...func(*config.In
 			}
 		}
 		publisherAddr = multiaddr.Join(parts...)
-		ingestCfg.HttpServer.ListenMultiaddr = publisherAddr.String()
+		ingestCfg.HttpPublisher.ListenMultiaddr = publisherAddr.String()
 
 	} else {
 		publisherAddr = h.Addrs()[0]

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -54,7 +54,7 @@ func TestRetrievalRoundTrip(t *testing.T) {
 	require.Len(t, roots, 1)
 	carBs.Close()
 
-	contextID := []byte("apples1auce")
+	contextID := []byte("applesauce")
 	md, err := cardatatransfer.MetadataFromContextID(contextID)
 	require.NoError(t, err)
 	advCid, err := server.cs.Put(ctx, contextID, filepath.Join(testutil.ThisDir(t), "./testdata/sample-v1-2.car"), md)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -56,8 +56,10 @@ type Engine struct {
 	cache     datastore.Datastore
 	// ds is the datastore used for persistence of different assets (advertisements,
 	// indexed data, etc.)
-	ds        datastore.Batching
-	publisher legs.Publisher
+	ds datastore.Batching
+
+	publisherKind config.PublisherKind
+	publisher     legs.Publisher
 
 	httpPublisherCfg *config.HttpPublisher
 
@@ -119,6 +121,7 @@ func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.
 
 		addrs:            retAddrs,
 		httpPublisherCfg: &ingestCfg.HttpPublisher,
+		publisherKind:    ingestCfg.PublisherKind,
 	}
 
 	e.cachelsys = e.cacheLinkSystem()
@@ -165,7 +168,7 @@ func (e *Engine) Start(ctx context.Context) error {
 
 	e.cache = dsCache
 
-	if e.httpPublisherCfg.Enabled {
+	if e.publisherKind == config.HttpPublisherKind {
 		var addr string
 		addr, err = e.httpPublisherCfg.ListenNetAddr()
 		if err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -278,13 +278,12 @@ func (e *Engine) Shutdown() error {
 	err := e.publisher.Close()
 	if err != nil {
 		err = fmt.Errorf("error closing leg publisher: %w", err)
-		return err
 	}
 	if cerr := e.cache.Close(); cerr != nil {
 		log.Errorw("Error closing link cache", "err", cerr)
 	}
 
-	return nil
+	return err
 }
 
 // GetAdv gets the advertisement associated to the given cid c.

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -59,7 +59,7 @@ type Engine struct {
 	ds        datastore.Batching
 	publisher legs.Publisher
 
-	httpPublisherCfg *config.HttpServer
+	httpPublisherCfg *config.HttpPublisher
 
 	// pubsubtopic where the provider will push advertisements
 	pubSubTopic     string
@@ -118,7 +118,7 @@ func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.
 		linkCacheSize:   ingestCfg.LinkCacheSize,
 
 		addrs:            retAddrs,
-		httpPublisherCfg: &ingestCfg.HttpServer,
+		httpPublisherCfg: &ingestCfg.HttpPublisher,
 	}
 
 	e.cachelsys = e.cacheLinkSystem()


### PR DESCRIPTION
## Context

go-legs supports syncing over http. But the index provider hasn't been hooked up to start the http server.

## Changes

This PR adds a config and logic to enable the http index provider via go-legs. It also includes a test in `e2e_retrieve_test.go` that syncs over http.