### PR TITLE
Rename Callback in interface

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -68,7 +68,7 @@ type Engine struct {
 	linkCacheSize int
 
 	// cb is the callback used in the linkSystem
-	cb   provider.Callback
+	cb   provider.ListMultihashCallback
 	cblk sync.Mutex
 }
 
@@ -215,7 +215,7 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 	return c, e.publisher.UpdateRoot(ctx, c)
 }
 
-// RegisterCallback registers a new provider.Callback that is used to look up the list of multihashes
+// RegisterListMultihashCallback registers a new provider.Callback that is used to look up the list of multihashes
 // associated to a context ID.
 // At least one such callback must be registered before calls to Engine.NotifyPut and Engine.NotifyRemove.
 //
@@ -223,7 +223,7 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 // Only a single callback is supported.
 //
 // See: provider.Interface
-func (e *Engine) RegisterCallback(cb provider.Callback) {
+func (e *Engine) RegisterListMultihashCallback(cb provider.ListMultihashCallback) {
 	log.Debugf("Registering callback in engine")
 	e.cblk.Lock()
 	defer e.cblk.Unlock()

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -54,7 +54,7 @@ func (s *sliceMhIterator) Next() (mh.Multihash, error) {
 // toCallback simply returns the list of multihashes for
 // testing purposes. A more complex callback could read
 // from the CID index and return the list of multihashes.
-func toCallback(mhs []mh.Multihash) provider.Callback {
+func toCallback(mhs []mh.Multihash) provider.ListMultihashCallback {
 	return func(_ context.Context, _ []byte) (provider.MultihashIterator, error) {
 		return &sliceMhIterator{mhs: mhs}, nil
 	}

--- a/interface.go
+++ b/interface.go
@@ -33,11 +33,11 @@ type Interface interface {
 	// represents the ID of the advertisement appended to the chain.
 	Publish(context.Context, schema.Advertisement) (cid.Cid, error)
 
-	// RegisterCallback registers the callback used by the provider to look up
+	// RegisterListMultihashCallback registers the callback used by the provider to look up
 	// a list of multihashes by context ID.  Only a single callback is
 	// supported; repeated calls to this function will replace the previous
 	// callback.
-	RegisterCallback(Callback)
+	RegisterListMultihashCallback(ListMultihashCallback)
 
 	// NotifyPut sginals to the provider that the list of multihashes looked up
 	// by the given contextID are available.  The given contextID is then used to look up
@@ -91,9 +91,9 @@ type MultihashIterator interface {
 	Next() (multihash.Multihash, error)
 }
 
-// Callback is used by provider to look up a list of multihashes associated to
+// ListMultihashCallback is used by provider to look up a list of multihashes associated to
 // a context ID.  The callback must be deterministic: it must produce the same
 // list of multihashes in the same order for the same context ID.
 //
 // See: Interface.NotifyPut, Interface.NotifyRemove, MultihashIterator.
-type Callback func(ctx context.Context, contextID []byte) (MultihashIterator, error)
+type ListMultihashCallback func(ctx context.Context, contextID []byte) (MultihashIterator, error)

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -130,16 +130,16 @@ func (mr *MockInterfaceMockRecorder) PublishLocal(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishLocal", reflect.TypeOf((*MockInterface)(nil).PublishLocal), arg0, arg1)
 }
 
-// RegisterCallback mocks base method.
-func (m *MockInterface) RegisterCallback(arg0 provider.Callback) {
+// RegisterListMultihashCallback mocks base method.
+func (m *MockInterface) RegisterListMultihashCallback(arg0 provider.ListMultihashCallback) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterCallback", arg0)
+	m.ctrl.Call(m, "RegisterListMultihashCallback", arg0)
 }
 
-// RegisterCallback indicates an expected call of RegisterCallback.
-func (mr *MockInterfaceMockRecorder) RegisterCallback(arg0 interface{}) *gomock.Call {
+// RegisterListMultihashCallback indicates an expected call of RegisterListMultihashCallback.
+func (mr *MockInterfaceMockRecorder) RegisterListMultihashCallback(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCallback", reflect.TypeOf((*MockInterface)(nil).RegisterCallback), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterListMultihashCallback", reflect.TypeOf((*MockInterface)(nil).RegisterListMultihashCallback), arg0)
 }
 
 // Shutdown mocks base method.
@@ -151,9 +151,9 @@ func (m *MockInterface) Shutdown() error {
 }
 
 // Shutdown indicates an expected call of Shutdown.
-func (mr *MockInterfaceMockRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Shutdown() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockInterface)(nil).Shutdown), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockInterface)(nil).Shutdown))
 }
 
 // MockMultihashIterator is a mock of MultihashIterator interface.

--- a/supplier/car_supplier.go
+++ b/supplier/car_supplier.go
@@ -53,7 +53,7 @@ func NewCarSupplier(eng provider.Interface, ds datastore.Datastore, opts ...car.
 		ds:   ds,
 		opts: opts,
 	}
-	eng.RegisterCallback(cs.Callback)
+	eng.RegisterListMultihashCallback(cs.Callback)
 	return cs
 }
 


### PR DESCRIPTION
`Callback` is a very generic name. Here's a draft PR we can discuss. My vote is for `ListMultihashCallback`.