### PR TITLE
Tell indexer to remove content by context ID

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/filecoin-project/go-data-transfer v1.12.1
 	github.com/filecoin-project/index-provider v0.0.0-20211115210313-7957526f5b07
-	github.com/filecoin-project/storetheindex v0.2.2
+	github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-graphsync v0.11.5

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -213,8 +213,8 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/g
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/storetheindex v0.2.2 h1:2zQlAtHKOVAfBpqIuQ8Njas3kM0VwgpicUCKC+epPG4=
-github.com/filecoin-project/storetheindex v0.2.2/go.mod h1:05vxs5u3vTQFAwGW9+pgWSMc3BgFOK513nPyIQyLwyQ=
+github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac h1:dg3LSQm60xa6FkbEtAIKrI7iVhAj2Nz5DP/cdfVWvIg=
+github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac/go.mod h1:05vxs5u3vTQFAwGW9+pgWSMc3BgFOK513nPyIQyLwyQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -428,16 +428,19 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 			return cid.Undef, err
 		}
 
-		// Provide the CID link to the content entries to give the indexer the
-		// option to remove all individual entries.  If a contextID is given
-		// then the indexer will delete all content for that contextID and not
-		// need to retrieve the entries.
-		cidsLnk = cidlink.Link{Cid: c}
+		// Create an advertisement to delete content by contextID by specifying
+		// that advertisement has no entries.
+		cidsLnk = schema.NoEntries
+
+		// To delete specific indexes values, provide the CID link to the
+		// content entries to delete.  The indexer will fetch these entries and
+		// delete indexes for the content in each entry chunk.
+		//   cidsLnk = cidlink.Link{Cid: c}
 
 		// The advertisement still requires a valid metadata even though it is
 		// not used for removal.  Create a valid empty metadata.
 		metadata = stiapi.Metadata{
-			ProtocolID: cardatatransfer.ContextIDCodec, //providerProtocolID,
+			ProtocolID: cardatatransfer.ContextIDCodec,
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/filecoin-project/go-data-transfer v1.12.1
 	github.com/filecoin-project/go-legs v0.2.1
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/storetheindex v0.2.2
+	github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.7.4

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/g
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/storetheindex v0.2.2 h1:2zQlAtHKOVAfBpqIuQ8Njas3kM0VwgpicUCKC+epPG4=
-github.com/filecoin-project/storetheindex v0.2.2/go.mod h1:05vxs5u3vTQFAwGW9+pgWSMc3BgFOK513nPyIQyLwyQ=
+github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac h1:dg3LSQm60xa6FkbEtAIKrI7iVhAj2Nz5DP/cdfVWvIg=
+github.com/filecoin-project/storetheindex v0.2.3-0.20220115024849-e3f769dd38ac/go.mod h1:05vxs5u3vTQFAwGW9+pgWSMc3BgFOK513nPyIQyLwyQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=


### PR DESCRIPTION
This change explicitly tells the indexer to remove content by context.  It does this by creating a removal ad that has no links and instead uses the special NoEntries link.

Depends on https://github.com/filecoin-project/storetheindex/pull/155
