### PR TITLE
Republish latest advertisement on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: vet test build
 
 build: TAG?=$(shell git describe --tags --abbrev=0)
 build: COMMIT?=$(shell git rev-parse HEAD)
-build: CLEAN?=$(shell git diff --quiet --exit-code || printf '-unclean')
+build: CLEAN?=$(shell git diff --quiet --exit-code || echo -n '-unclean')
 build:
 	cd $(BIN_SUBDIR) && go build -ldflags="-X 'main.version=$(TAG)-$(COMMIT)$(CLEAN)'"
 

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.13.0
-	github.com/filecoin-project/index-provider v0.0.0-20211115210313-7957526f5b07
+	github.com/filecoin-project/index-provider v0.2.1
 	github.com/filecoin-project/storetheindex v0.2.3
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-ds-leveldb v0.5.0

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -202,8 +202,9 @@ github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.7/go.mod h1:6YD7KwDOQ+03DdAitviL7h1fksIU6a4j52yPnA/E1PU=
-github.com/filecoin-project/go-legs v0.2.2 h1:tCCqiXpXw8219/l191phtp7BZbssm7hJcnFFTESs2NI=
 github.com/filecoin-project/go-legs v0.2.2/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
+github.com/filecoin-project/go-legs v0.2.3 h1:sNEUF+Cw4mpGp8hX4oZO/lIAiZpbJy55ih2GxXhj+V0=
+github.com/filecoin-project/go-legs v0.2.3/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=

--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -169,6 +169,11 @@ func daemonCommand(cctx *cli.Context) error {
 		defer bootstrapper.Close()
 	}
 
+	err = eng.PublishLatest(cctx.Context)
+	if err != nil {
+		log.Errorw("Could not republish latest advertisement", "err", err)
+	}
+
 	var finalErr error
 	// Keep process running.
 	select {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -3,7 +3,6 @@ package engine
 import (
 	"context"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"sync"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/filecoin-project/index-provider/engine/lrustore"
 	stiapi "github.com/filecoin-project/storetheindex/api/v0"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/hashicorp/go-multierror"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dsn "github.com/ipfs/go-datastore/namespace"
@@ -139,8 +139,7 @@ func NewFromConfig(cfg config.Config, dt dt.Manager, host host.Host, ds datastor
 	log.Info("Instantiating a new index provider engine")
 	privKey, err := cfg.Identity.DecodePrivateKey("")
 	if err != nil {
-		log.Errorw("Error decoding private key from provider", "err", err)
-		return nil, err
+		return nil, fmt.Errorf("cannot decode private key: %s", err)
 	}
 	return New(cfg.Ingest, privKey, dt, host, ds, cfg.ProviderServer.RetrievalMultiaddrs)
 }
@@ -172,8 +171,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		var addr string
 		addr, err = e.httpPublisherCfg.ListenNetAddr()
 		if err != nil {
-			log.Errorw("Error forming http addr in engine for httpPublisher:", "err", err)
-			return err
+			return fmt.Errorf("cannot format http addr for httpPublisher: %s", err)
 		}
 		e.publisher, err = httpsync.NewPublisher(addr, e.lsys, e.host.ID(), e.privKey)
 	} else {
@@ -181,8 +179,7 @@ func (e *Engine) Start(ctx context.Context) error {
 	}
 
 	if err != nil {
-		log.Errorw("Error initializing publisher in engine:", "err", err)
-		return err
+		return fmt.Errorf("cannot initialize publisher: %s", err)
 	}
 
 	return nil
@@ -197,8 +194,7 @@ func (e *Engine) Start(ctx context.Context) error {
 func (e *Engine) PublishLocal(ctx context.Context, adv schema.Advertisement) (cid.Cid, error) {
 	adLnk, err := schema.AdvertisementLink(e.lsys, adv)
 	if err != nil {
-		log.Errorw("Error generating advertisement link", "err", err)
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("cannot generate advertisement link: %s", err)
 	}
 
 	c := adLnk.ToCid()
@@ -209,8 +205,7 @@ func (e *Engine) PublishLocal(ctx context.Context, adv schema.Advertisement) (ci
 	log.Infow("Storing advertisement locally", "cid", c.String())
 	err = e.putLatestAdv(ctx, c.Bytes())
 	if err != nil {
-		log.Errorw("Error storing latest advertisement in blockstore", "err", err)
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("cannot store latest advertisement in blockstore: %s", err)
 	}
 	return c, nil
 }
@@ -225,12 +220,11 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 	// Store the advertisement locally.
 	c, err := e.PublishLocal(ctx, adv)
 	if err != nil {
-		log.Errorw("Failed to publish advertisement locally", "err", err)
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("failed to publish advertisement locally: %s", err)
 	}
 
-	log.Infow("Publishing advertisement in pubsub channel", "cid", c.String())
-	// Use legPublisher to publish the advertisement.
+	log.Infow("Publishing advertisement in pubsub channel", "cid", c)
+	// Publish the advertisement.
 	err = e.publisher.UpdateRoot(ctx, c)
 	if err != nil {
 		return cid.Undef, err
@@ -238,9 +232,27 @@ func (e *Engine) Publish(ctx context.Context, adv schema.Advertisement) (cid.Cid
 	return c, nil
 }
 
-// RegisterCallback registers a new provider.Callback that is used to look up the list of multihashes
-// associated to a context ID.
-// At least one such callback must be registered before calls to Engine.NotifyPut and Engine.NotifyRemove.
+// PublishLatest re-publishes the latest existing advertisement to pubsub.
+func (e *Engine) PublishLatest(ctx context.Context) error {
+	adCid, err := e.getLatestAdCid(ctx)
+	if err != nil {
+		return fmt.Errorf("could not get latest advertisement cid from blockstore: %s", err)
+	}
+
+	if adCid == cid.Undef {
+		log.Info("No previously published advertisements")
+		return nil
+	}
+
+	log.Infow("Republishing latest advertisement", "cid", adCid)
+
+	// Re-publish the advertisement.
+	return e.publisher.UpdateRoot(ctx, adCid)
+}
+
+// RegisterCallback registers a provider.Callback that is used to look up the
+// list of multihashes associated to a context ID. At least one such callback
+// must be registered before calls to Engine.NotifyPut and Engine.NotifyRemove.
 //
 // Note that successive calls to this function will replace the previous callback.
 // Only a single callback is supported.
@@ -253,8 +265,10 @@ func (e *Engine) RegisterCallback(cb provider.Callback) {
 	e.cb = cb
 }
 
-// NotifyPut publishes an advertisement that signals the list of multihashes associated to the given
-// contextID is available by this provider with the given metadata.
+// NotifyPut publishes an advertisement that signals the list of multihashes
+// associated to the given contextID is available by this provider with the
+// given metadata. A provider.Callback is required, and is used to look up the
+// list of multihashes associated to a context ID.
 //
 // Note that prior to calling this function a provider.Callback must be registered.
 //
@@ -278,86 +292,87 @@ func (e *Engine) NotifyRemove(ctx context.Context, contextID []byte) (cid.Cid, e
 // Shutdown shuts down the engine and discards all resources opened by the engine.
 // The engine is no longer usable after the call to this function.
 func (e *Engine) Shutdown() error {
+	var errs error
 	err := e.publisher.Close()
 	if err != nil {
-		err = fmt.Errorf("error closing leg publisher: %w", err)
+		errs = multierror.Append(errs, fmt.Errorf("error closing leg publisher: %s", err))
 	}
-	if cerr := e.cache.Close(); cerr != nil {
-		log.Errorw("Error closing link cache", "err", cerr)
+	if err = e.cache.Close(); err != nil {
+		errs = multierror.Append(errs, fmt.Errorf("error closing link cache: %s", err))
 	}
 
-	return err
+	return errs
 }
 
 // GetAdv gets the advertisement associated to the given cid c.
 // The context is not used.
-func (e *Engine) GetAdv(_ context.Context, c cid.Cid) (schema.Advertisement, error) {
-	log.Infow("Getting advertisement", "cid", c)
-	l, err := schema.LinkAdvFromCid(c).AsLink()
+func (e *Engine) GetAdv(_ context.Context, adCid cid.Cid) (schema.Advertisement, error) {
+	log := log.With("cid", adCid)
+	log.Infow("Getting advertisement by CID")
+
+	l, err := schema.LinkAdvFromCid(adCid).AsLink()
 	if err != nil {
-		log.Errorw("Error getting Advertisement link from its CID", "cid", c, "err", err)
-		return nil, err
+		return nil, fmt.Errorf("cannot convert cid to advertisement link: %s", err)
 	}
 
 	lsys := e.vanillaLinkSystem()
 	n, err := lsys.Load(ipld.LinkContext{}, l, schema.Type.Advertisement)
 	if err != nil {
-		log.Errorw("Error loading advertisement from blockstore with vanilla lsys", "err", err)
-		return nil, err
+		return nil, fmt.Errorf("cannot load advertisement from blockstore with vanilla linksystem: %s", err)
 	}
 	adv, ok := n.(schema.Advertisement)
 	if !ok {
-		log.Errorw("Stored IPLD node for cid is not advertisement", "cid", c)
-		return nil, errors.New("stored IPLD node not of advertisement type")
+		return nil, fmt.Errorf("stored IPLD node for cid is not an advertisement")
 	}
 	return adv, nil
 }
 
-// GetLatestAdv gets the latest advertisement by the provider.
-// Note that the latest advertisement may or may not have been published onto the gossipsub topic.
-//
-// The context is used to retrieve date from the local datastore.
+// GetLatestAdv gets the latest advertisement by the provider.  If there are
+// not previously published advertisements, then cid.Undef is returned as the
+// advertisement CID.
 func (e *Engine) GetLatestAdv(ctx context.Context) (cid.Cid, schema.Advertisement, error) {
 	log.Info("Getting latest advertisement")
-	latestAdv, err := e.getLatestAdv(ctx)
+	latestAdCid, err := e.getLatestAdCid(ctx)
 	if err != nil {
-		log.Errorw("Failed to fetch latest advertisement from blockstore", "err", err)
-		return cid.Undef, nil, err
+		return cid.Undef, nil, fmt.Errorf("could not get latest advertisement cid from blockstore: %s", err)
 	}
-	ad, err := e.GetAdv(ctx, latestAdv)
+	if latestAdCid == cid.Undef {
+		return cid.Undef, nil, nil
+	}
+
+	ad, err := e.GetAdv(ctx, latestAdCid)
 	if err != nil {
-		log.Errorw("Latest advertisement could not be retrieved from blockstore by CID", "err", err)
-		return cid.Undef, nil, err
+		return cid.Undef, nil, fmt.Errorf("count not get latest advertisement from blockstore by cid: %s", err)
 	}
-	return latestAdv, ad, nil
+	return latestAdCid, ad, nil
 }
 
 func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metadata stiapi.Metadata, isRm bool) (cid.Cid, error) {
 	var err error
 	var cidsLnk cidlink.Link
 
-	// If no callback registered return error
-	if e.cb == nil {
-		log.Error("No callback defined in engine")
-		return cid.Undef, provider.ErrNoCallback
-	}
-
 	log := log.With("contextID", base64.StdEncoding.EncodeToString(contextID))
 
 	c, err := e.getKeyCidMap(ctx, contextID)
 	if err != nil {
 		if err != datastore.ErrNotFound {
-			log.Errorw("Could not get mapping between contextID and CID of linked list", "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("cound not not get entries cid by context id: %s", err)
 		}
 	}
 
 	// If we are not removing, we need to generate the link for the list
 	// of CIDs from the contextID using the callback, and store the relationship
 	if !isRm {
+		log.Info("Creating advertisement")
+
 		// If no previously-published ad for this context ID.
 		if c == cid.Undef {
-			log.Info("Generating linked list of CIDs for advertisement")
+			log.Info("Generating entries linked list for advertisement")
+			// If no callback registered return error
+			if e.cb == nil {
+				return cid.Undef, provider.ErrNoCallback
+			}
+
 			// Call the callback
 			mhIter, err := e.cb(ctx, contextID)
 			if err != nil {
@@ -367,8 +382,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 			// advertisement and used for ingestion.
 			lnk, err := e.generateChunks(mhIter)
 			if err != nil {
-				log.Errorw("Error generating link from list of CIDs", "err", err)
-				return cid.Undef, err
+				return cid.Undef, fmt.Errorf("could not generate entries list: %s", err)
 			}
 			cidsLnk = lnk.(cidlink.Link)
 
@@ -376,18 +390,16 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 			// list of Cids.
 			err = e.putKeyCidMap(ctx, contextID, cidsLnk.Cid)
 			if err != nil {
-				log.Errorw("Could not set mapping between contextID and CID of linked list", "err", err)
-				return cid.Undef, err
+				return cid.Undef, fmt.Errorf("failed to write context id to entries cid mapping: %s", err)
 			}
 		} else {
 			// Lookup metadata for this contextID.
 			prevMetadata, err := e.getKeyMetadataMap(ctx, contextID)
 			if err != nil {
 				if err != datastore.ErrNotFound {
-					log.Errorw("Could not get metadata for existing chain", "err", err)
-					return cid.Undef, err
+					return cid.Undef, fmt.Errorf("could not get metadata for context id: %s", err)
 				}
-				log.Warn("No metadata for existing chain, generating new advertisement")
+				log.Warn("No metadata for existing context ID, generating new advertisement")
 			}
 
 			if metadata.Equal(prevMetadata) {
@@ -401,31 +413,28 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 		}
 
 		if err = e.putKeyMetadataMap(ctx, contextID, metadata); err != nil {
-			log.Errorw("Could not set mapping between contextID and metadata", "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("failed to write context id to metadata mapping: %s", err)
 		}
 	} else {
+		log.Info("Creating removal advertisement")
+
 		if c == cid.Undef {
 			return cid.Undef, provider.ErrContextIDNotFound
 		}
-		log.Info("Generating removal list for advertisement")
 
 		// And if we are removing it means we probably do not have the list of
 		// CIDs anymore, so we can remove the entry from the datastore.
 		err = e.deleteKeyCidMap(ctx, contextID)
 		if err != nil {
-			log.Errorw("Failed deleting Key-Cid map for contextID", "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("failed to delete context id to entries cid mapping: %s", err)
 		}
 		err = e.deleteCidKeyMap(ctx, c)
 		if err != nil {
-			log.Errorw("Failed deleting Cid-Key map for lookup cid", "cid", c, "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("failed to delete entries cid to context id mapping: %s", err)
 		}
 		err = e.deleteKeyMetadataMap(ctx, contextID)
 		if err != nil {
-			log.Errorw("Failed deleting Key-Metadata map for contextID", "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("failed to delete context id to metadata mapping: %s", err)
 		}
 
 		// Create an advertisement to delete content by contextID by specifying
@@ -436,31 +445,29 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 		// content entries to delete.  The indexer will fetch these entries and
 		// delete indexes for the content in each entry chunk.
 
-		// The advertisement still requires a valid metadata even though it is
-		// not used for removal.  Create a valid empty metadata.
+		// The advertisement still requires a valid metadata even though
+		// metadata is not used for removal.  Create a valid empty metadata.
 		metadata = stiapi.Metadata{
 			ProtocolID: cardatatransfer.ContextIDCodec,
 		}
 	}
 
-	// Get the latest advertisement that was generated
-	latestAdvID, err := e.getLatestAdv(ctx)
+	// Get the previous advertisement that was generated
+	prevAdvID, err := e.getLatestAdCid(ctx)
 	if err != nil {
-		log.Errorw("Could not get latest advertisement", "err", err)
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("could not get latest advertisement: %s", err)
 	}
 	var previousLnk schema.Link_Advertisement
 	// Check for cid.Undef for the previous link. If this is the case, then
 	// this means there is a "cid too short" error in IPLD links serialization.
-	if latestAdvID == cid.Undef {
-		log.Warn("Latest advertisement CID was undefined")
+	if prevAdvID == cid.Undef {
+		log.Info("Latest advertisement CID was undefined - no previous advertisement")
 		previousLnk = nil
 	} else {
 		nb := schema.Type.Link_Advertisement.NewBuilder()
-		err = nb.AssignLink(cidlink.Link{Cid: latestAdvID})
+		err = nb.AssignLink(cidlink.Link{Cid: prevAdvID})
 		if err != nil {
-			log.Errorw("Error generating link from latest advertisement", "err", err)
-			return cid.Undef, err
+			return cid.Undef, fmt.Errorf("failed to generate link from latest advertisement cid: %s", err)
 		}
 		previousLnk = nb.Build().(schema.Link_Advertisement)
 	}
@@ -468,8 +475,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 	adv, err := schema.NewAdvertisement(e.privKey, previousLnk, cidsLnk,
 		contextID, metadata, isRm, e.host.ID().String(), e.addrs)
 	if err != nil {
-		log.Errorw("Error generating new advertisement", "err", err)
-		return cid.Undef, err
+		return cid.Undef, fmt.Errorf("failed to create advertisement: %s", err)
 	}
 	return e.Publish(ctx, adv)
 }
@@ -535,7 +541,7 @@ func (e *Engine) putLatestAdv(ctx context.Context, advID []byte) error {
 	return e.ds.Put(ctx, dsLatestAdvKey, advID)
 }
 
-func (e *Engine) getLatestAdv(ctx context.Context) (cid.Cid, error) {
+func (e *Engine) getLatestAdCid(ctx context.Context) (cid.Cid, error) {
 	b, err := e.ds.Get(ctx, dsLatestAdvKey)
 	if err != nil {
 		if err == datastore.ErrNotFound {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -198,7 +198,7 @@ func TestPublishLocal(t *testing.T) {
 	// Check that the Cid has been generated successfully
 	require.Equal(t, advCid, advLnk.ToCid(), "advertisement CID from link and published CID not equal")
 	// Check that latest advertisement is set correctly
-	latest, err := e.getLatestAdv(ctx)
+	latest, err := e.getLatestAdCid(ctx)
 	require.NoError(t, err)
 	require.Equal(t, latest, advCid, "latest advertisement pointer not updated correctly")
 	// Publish new advertisement.
@@ -206,7 +206,7 @@ func TestPublishLocal(t *testing.T) {
 	advCid2, err := e.PublishLocal(ctx, adv2)
 	require.NoError(t, err)
 	// Latest advertisement should be updates and we are able to still fetch the previous one.
-	latest, err = e.getLatestAdv(ctx)
+	latest, err = e.getLatestAdCid(ctx)
 	require.NoError(t, err)
 	require.Equal(t, latest, advCid2, "latest advertisement pointer not updated correctly")
 	// Check that we can fetch the latest advertisement
@@ -219,6 +219,11 @@ func TestPublishLocal(t *testing.T) {
 	require.NoError(t, err)
 	fAdv := schema.Advertisement(fetchAdv)
 	require.Equal(t, ipld.DeepEqual(fAdv, adv), true, "fetched advertisement is not equal to published one")
+	// Check that latest can be republished.
+	err = e.PublishLatest(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestNotifyPublish(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,13 @@ go 1.16
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.13.0
-	github.com/filecoin-project/go-legs v0.2.2
+	github.com/filecoin-project/go-legs v0.2.3
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/storetheindex v0.2.3
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.7.4
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs/go-cid v0.1.0
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-graphsync v0.12.0

--- a/go.sum
+++ b/go.sum
@@ -202,8 +202,9 @@ github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.7/go.mod h1:6YD7KwDOQ+03DdAitviL7h1fksIU6a4j52yPnA/E1PU=
-github.com/filecoin-project/go-legs v0.2.2 h1:tCCqiXpXw8219/l191phtp7BZbssm7hJcnFFTESs2NI=
 github.com/filecoin-project/go-legs v0.2.2/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
+github.com/filecoin-project/go-legs v0.2.3 h1:sNEUF+Cw4mpGp8hX4oZO/lIAiZpbJy55ih2GxXhj+V0=
+github.com/filecoin-project/go-legs v0.2.3/go.mod h1:mdNMISV/bWyZguFM7R4s0mxV1v6Vhda3BiAw9+jv5iE=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=

--- a/interface.go
+++ b/interface.go
@@ -39,12 +39,13 @@ type Interface interface {
 	// callback.
 	RegisterCallback(Callback)
 
-	// NotifyPut sginals to the provider that the list of multihashes looked up
-	// by the given contextID are available.  The given contextID is then used to look up
-	// the list of multihashes via Callback.  An advertisement is then
+	// NotifyPut signals the provider that the list of multihashes looked up by
+	// the given contextID is available.  The given contextID is then used to
+	// look up the list of multihashes via Callback.  An advertisement is then
 	// generated, appended to the chain of advertisements and published onto
 	// the gossip pubsub channel.
-	// Therefore, a Callback must be registered prior to using this function.
+	//
+	// A Callback must be registered prior to using this function.
 	// ErrNoCallback is returned if no such callback is registered.
 	//
 	// The metadata is data that provides hints about how to retrieve data and


### PR DESCRIPTION
Republishes the latest advertisement on startup for the following reasons:
- Set the publisher's latest head CID
- Send last advertisement that may have been missed by new indexers that joined network during downtime
- Send last ads that was not published because of some reason that required provider restart

This change also stops the engine from logging the same errors that are also returned.  Errors should either be returned or logged, not both.

Fixes #145 