### PR TITLE
Implement command to list provider advertisement

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,9 +4,11 @@ go 1.16
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.13.0
+	github.com/filecoin-project/go-legs v0.2.3
 	github.com/filecoin-project/index-provider v0.2.1
 	github.com/filecoin-project/storetheindex v0.2.3
 	github.com/ipfs/go-cid v0.1.0
+	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-graphsync v0.12.0
 	github.com/ipfs/go-ipfs v0.11.0
@@ -14,6 +16,7 @@ require (
 	github.com/ipld/go-car/v2 v2.1.1
 	github.com/ipld/go-ipld-prime v0.14.4
 	github.com/libp2p/go-libp2p v0.17.0
+	github.com/libp2p/go-libp2p-core v0.13.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multicodec v0.4.0

--- a/cmd/provider/get.go
+++ b/cmd/provider/get.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"github.com/filecoin-project/index-provider/cmd/provider/internal"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/urfave/cli/v2"
+)
+
+var (
+	adCid      = cid.Undef
+	provClient internal.ProviderClient
+
+	pAddrInfo    string
+	topic        string
+	printEntries bool
+	GetAdCmd     = &cli.Command{
+		Name:        "get-ad",
+		Usage:       "Gets advertisement",
+		ArgsUsage:   "[ad-cid]",
+		Description: "Advertisement CID may optionally be specified as the first argument. If not specified the latest advertisement is used.",
+		Before:      beforeGetAdvertisements,
+		Action:      doGetAdvertisements,
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name: "provider-addr-info",
+				Usage: "The provider's endpoint address in form of libp2p multiaddr info. " +
+					"Example GraphSync endpoint: /ip4/1.2.3.4/tcp/1234/p2p/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ  " +
+					"Example HTTP endpoint: /ip4/1.2.3.4/tcp/1234/http/12D3KooWE8yt84RVwW3sFcd6WMjbUdWrZer2YtT4dmtj3dHdahSZ",
+				Aliases:     []string{"p"},
+				Destination: &pAddrInfo,
+				Required:    true,
+			},
+			&cli.StringFlag{
+				Name:        "topic",
+				Usage:       "The topic on which index advertisements are published. Only needed if connecting to provider via Graphsync endpoint.",
+				Value:       "indexer/ingest",
+				Aliases:     []string{"t"},
+				Destination: &topic,
+			},
+			&cli.BoolFlag{
+				Name:        "print-entries",
+				Usage:       "Whether to print the list of entries in advertisement",
+				Aliases:     []string{"e"},
+				Destination: &printEntries,
+			},
+		},
+	}
+)
+
+func beforeGetAdvertisements(cctx *cli.Context) error {
+	var err error
+	if cctx.NArg() > 1 {
+		return cli.Exit("At most one argument [ad-cid] must be specified. If none is specified, the current head advertisement is fetched.", 1)
+	}
+	if cctx.Args().Present() {
+		adCid, err = cid.Decode(cctx.Args().First())
+		if err != nil {
+			return err
+		}
+	}
+
+	addr, err := multiaddr.NewMultiaddr(pAddrInfo)
+	if err != nil {
+		return err
+	}
+	addrInfos, err := peer.AddrInfosFromP2pAddrs(addr)
+	if err != nil {
+		return err
+	}
+
+	addrInfo := addrInfos[0]
+
+	var isHttp bool
+	for _, p := range addrInfo.Addrs[0].Protocols() {
+		if p.Code == multiaddr.P_HTTP || p.Code == multiaddr.P_HTTPS {
+			isHttp = true
+			break
+		}
+	}
+
+	if isHttp {
+		provClient, err = internal.NewHttpProviderClient(addrInfo)
+		if err != nil {
+			return err
+		}
+	} else {
+		if topic == "" {
+			return cli.Exit("topic must be configured when graphsync endpoint is specified.", 1)
+		}
+		provClient, err = internal.NewGraphSyncProviderClient(addrInfo, topic)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func doGetAdvertisements(cctx *cli.Context) error {
+	ad, err := provClient.GetAdvertisement(cctx.Context, adCid)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("ID:          %s\n", ad.ID)
+	fmt.Printf("PreviousID:  %s\n", ad.PreviousID)
+	fmt.Printf("ProviderID:  %s\n", ad.ProviderID)
+	fmt.Printf("Addresses:   %v\n", ad.Addresses)
+	fmt.Printf("Is Remove:   %v\n", ad.IsRemove)
+
+	fmt.Println("Entries:")
+	entries, cc, err := ad.Entries.Drain()
+	if err != nil {
+		return err
+	}
+
+	if printEntries {
+		for _, mh := range entries {
+			fmt.Printf("  %s\n", mh)
+		}
+		fmt.Println("  ---------------------")
+	}
+	fmt.Printf("  Chunk Count: %d\n", cc)
+	fmt.Printf("  Total Count: %d\n", len(entries))
+	return nil
+}

--- a/cmd/provider/internal/client.go
+++ b/cmd/provider/internal/client.go
@@ -1,0 +1,104 @@
+package internal
+
+import (
+	"context"
+	"errors"
+	"github.com/filecoin-project/go-legs"
+	"github.com/filecoin-project/go-legs/httpsync"
+	"time"
+
+	"github.com/filecoin-project/go-legs/dtsync"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var (
+	ssb                 = selectorbuilder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+	oneAdWithAllEntries = ssb.ExploreUnion(
+		ssb.ExploreRecursive(selector.RecursionLimitDepth(1), ssb.ExploreFields(
+			func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
+				efsb.Insert("PreviousID", ssb.ExploreRecursiveEdge())
+			})),
+		ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreFields( //TODO parameterize limit
+			func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
+				efsb.Insert("Next", ssb.ExploreRecursiveEdge())
+				efsb.Insert("Entries", ssb.ExploreRecursiveEdge())
+			})),
+	).Node()
+)
+
+type (
+	ProviderClient interface {
+		GetAdvertisement(ctx context.Context, id cid.Cid) (*Advertisement, error)
+		Close() error
+	}
+	providerGraphSyncClient struct {
+		close  func() error
+		syncer legs.Syncer
+		store  *ProviderClientStore
+	}
+)
+
+func NewHttpProviderClient(provAddr peer.AddrInfo) (ProviderClient, error) {
+	store := newProviderClientStore()
+	hsync := httpsync.NewSync(store.LinkSystem, nil, nil)
+	syncer, err := hsync.NewSyncer(provAddr.ID, provAddr.Addrs[0])
+	if err != nil {
+		return nil, err
+	}
+	return &providerGraphSyncClient{
+		close: func() error {
+			hsync.Close()
+			return nil
+		},
+		syncer: syncer,
+		store:  store,
+	}, nil
+}
+
+func NewGraphSyncProviderClient(provAddr peer.AddrInfo, topic string) (ProviderClient, error) {
+	h, err := libp2p.New()
+	if err != nil {
+		return nil, err
+	}
+	h.Peerstore().AddAddrs(provAddr.ID, provAddr.Addrs, time.Hour)
+
+	store := newProviderClientStore()
+	dtSync, err := dtsync.NewSync(h, store.Batching, store.LinkSystem, nil)
+	if err != nil {
+		return nil, err
+	}
+	syncer := dtSync.NewSyncer(provAddr.ID, topic)
+	return &providerGraphSyncClient{
+		close:  dtSync.Close,
+		syncer: syncer,
+		store:  store,
+	}, nil
+}
+
+func (p *providerGraphSyncClient) GetAdvertisement(ctx context.Context, id cid.Cid) (*Advertisement, error) {
+	if id == cid.Undef {
+		head, err := p.syncer.GetHead(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		if head == cid.Undef {
+			return nil, errors.New("no head advertisement exists")
+		}
+		id = head
+	}
+
+	if err := p.syncer.Sync(ctx, id, oneAdWithAllEntries); err != nil {
+		return nil, err
+	}
+	return p.store.getAdvertisement(ctx, id)
+}
+
+func (p *providerGraphSyncClient) Close() error {
+	return p.close()
+}

--- a/cmd/provider/internal/client_store.go
+++ b/cmd/provider/internal/client_store.go
@@ -1,0 +1,185 @@
+package internal
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/codec/dagjson"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/multiformats/go-multihash"
+	"io"
+)
+
+type (
+	ProviderClientStore struct {
+		datastore.Batching
+		ipld.LinkSystem
+	}
+
+	Advertisement struct {
+		ID         cid.Cid
+		PreviousID cid.Cid
+		ProviderID peer.ID
+		ContextID  []byte
+		Metadata   []byte
+		Addresses  []string
+		Signature  []byte
+		Entries    *EntriesIterator
+		IsRemove   bool
+	}
+)
+
+func newProviderClientStore() *ProviderClientStore {
+	store := dssync.MutexWrap(datastore.NewMapDatastore())
+	lsys := cidlink.DefaultLinkSystem()
+	lsys.StorageReadOpener = func(lctx ipld.LinkContext, lnk ipld.Link) (io.Reader, error) {
+		c := lnk.(cidlink.Link).Cid
+		val, err := store.Get(lctx.Ctx, datastore.NewKey(c.String()))
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewBuffer(val), nil
+	}
+	lsys.StorageWriteOpener = func(lctx ipld.LinkContext) (io.Writer, ipld.BlockWriteCommitter, error) {
+		buf := bytes.NewBuffer(nil)
+		return buf, func(lnk ipld.Link) error {
+			c := lnk.(cidlink.Link).Cid
+			return store.Put(lctx.Ctx, datastore.NewKey(c.String()), buf.Bytes())
+		}, nil
+	}
+	return &ProviderClientStore{
+		Batching:   store,
+		LinkSystem: lsys,
+	}
+}
+
+func (s *ProviderClientStore) getEntriesChunk(ctx context.Context, target cid.Cid) (cid.Cid, []multihash.Multihash, error) {
+	val, err := s.Batching.Get(ctx, datastore.NewKey(target.String()))
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+	nb := schema.Type.EntryChunk.NewBuilder()
+	err = dagjson.Decode(nb, bytes.NewBuffer(val))
+	if err != nil {
+		return cid.Undef, nil, err
+	}
+
+	node := nb.Build().(schema.EntryChunk)
+	var next cid.Cid
+	if node.FieldNext().IsAbsent() || node.FieldNext().IsNull() {
+		next = cid.Undef
+	} else {
+		lnk, err := node.FieldNext().AsNode().AsLink()
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+		next = lnk.(cidlink.Link).Cid
+	}
+
+	node.FieldEntries()
+	cit := node.FieldEntries().ListIterator()
+	var mhs []multihash.Multihash
+	for !cit.Done() {
+		_, cnode, _ := cit.Next()
+		h, err := cnode.AsBytes()
+		if err != nil {
+			return cid.Undef, nil, fmt.Errorf("cannot decode an entry from the ingestion list: %s", err)
+		}
+		_, m, err := multihash.MHFromBytes(h)
+		if err != nil {
+			return cid.Undef, nil, err
+		}
+		mhs = append(mhs, m)
+	}
+	return next, mhs, nil
+}
+
+func (s *ProviderClientStore) getAdvertisement(ctx context.Context, id cid.Cid) (*Advertisement, error) {
+	val, err := s.Batching.Get(ctx, datastore.NewKey(id.String()))
+	if err != nil {
+		return nil, err
+	}
+
+	nb := schema.Type.Advertisement.NewBuilder()
+	err = dagjson.Decode(nb, bytes.NewBuffer(val))
+	if err != nil {
+		return nil, err
+	}
+	node := nb.Build().(schema.Advertisement)
+
+	provid, err := node.FieldProvider().AsString()
+	if err != nil {
+		return nil, err
+	}
+
+	contextID, err := node.FieldContextID().AsBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	meta, err := node.FieldMetadata().AsBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	adds, err := schema.IpldToGoStrings(node.FieldAddresses())
+	if err != nil {
+		return nil, err
+	}
+	var prevCid cid.Cid
+	if node.FieldPreviousID().Exists() {
+		lnk, err := node.FieldPreviousID().Must().AsLink()
+		if err != nil {
+			return nil, err
+		} else {
+			prevCid = lnk.(cidlink.Link).Cid
+		}
+	}
+
+	sign, err := node.FieldSignature().AsBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	elink, err := node.FieldEntries().AsLink()
+	if err != nil {
+		return nil, err
+	}
+	entriesCid := elink.(cidlink.Link).Cid
+
+	isRm, err := node.FieldIsRm().AsBool()
+	if err != nil {
+		return nil, err
+	}
+
+	dprovid, err := peer.Decode(provid)
+	if err != nil {
+		return nil, err
+	}
+
+	a := &Advertisement{
+		ID:         id,
+		ProviderID: dprovid,
+		ContextID:  contextID,
+		Metadata:   meta,
+		Addresses:  adds,
+		PreviousID: prevCid,
+		Signature:  sign,
+		Entries: &EntriesIterator{
+			root:  entriesCid,
+			next:  entriesCid,
+			ctx:   ctx,
+			store: s,
+		},
+		IsRemove: isRm,
+	}
+	return a, nil
+}
+
+// TODO: add advertisement signature verification

--- a/cmd/provider/internal/entries_iter.go
+++ b/cmd/provider/internal/entries_iter.go
@@ -1,0 +1,76 @@
+package internal
+
+import (
+	"context"
+	provider "github.com/filecoin-project/index-provider"
+	"github.com/ipfs/go-cid"
+	"github.com/multiformats/go-multihash"
+	"io"
+)
+
+var (
+	_ provider.MultihashIterator = (*EntriesIterator)(nil)
+	_ provider.MultihashIterator = (*sliceMhIterator)(nil)
+)
+
+type (
+	EntriesIterator struct {
+		store      *ProviderClientStore
+		ctx        context.Context
+		root       cid.Cid
+		next       cid.Cid
+		chunkIter  *sliceMhIterator
+		chunkCount int
+	}
+	sliceMhIterator struct {
+		mhs    []multihash.Multihash
+		offset int
+	}
+)
+
+func (d *EntriesIterator) Next() (multihash.Multihash, error) {
+	if d.chunkIter != nil && d.chunkIter.hasNext() {
+		return d.chunkIter.Next()
+	}
+
+	if d.next == cid.Undef {
+		return nil, io.EOF
+	}
+
+	next, mhs, err := d.store.getEntriesChunk(d.ctx, d.next)
+	if err != nil {
+		return nil, err
+	}
+	d.next = next
+	d.chunkIter = &sliceMhIterator{mhs: mhs}
+	d.chunkCount++
+	return d.chunkIter.Next()
+}
+
+func (d *EntriesIterator) Drain() ([]multihash.Multihash, int, error) {
+	var mhs []multihash.Multihash
+	for {
+		mh, err := d.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, d.chunkCount, err
+		}
+		mhs = append(mhs, mh)
+	}
+	return mhs, d.chunkCount, nil
+}
+
+func (s *sliceMhIterator) Next() (multihash.Multihash, error) {
+	if s.hasNext() {
+		next := s.mhs[s.offset]
+		s.offset++
+		return next, nil
+	}
+	return nil, io.EOF
+}
+
+func (s *sliceMhIterator) hasNext() bool {
+	return s.offset < len(s.mhs)
+}

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -37,7 +37,6 @@ func run() int {
 	}()
 
 	app := &cli.App{
-
 		Name:    "provider",
 		Usage:   "Indexer Reference Provider Implementation",
 		Version: version,
@@ -51,6 +50,7 @@ func run() int {
 			RegisterCmd,
 			RemoveCmd,
 			VerifyIngestCmd,
+			GetAdCmd,
 		},
 	}
 

--- a/cmd/provider/verify_ingest.go
+++ b/cmd/provider/verify_ingest.go
@@ -327,9 +327,7 @@ func (r *verifyIngestResult) printAndExit() error {
 }
 
 func verifyIngestFromCarIterableIndex(finder *httpfinderclient.Client, idx index.IterableIndex) (*verifyIngestResult, error) {
-	result := &verifyIngestResult{}
 	var mhs []multihash.Multihash
-
 	if err := idx.ForEach(func(mh multihash.Multihash, _ uint64) error {
 		if include() {
 			mhs = append(mhs, mh)
@@ -338,7 +336,11 @@ func verifyIngestFromCarIterableIndex(finder *httpfinderclient.Client, idx index
 	}); err != nil {
 		return nil, err
 	}
+	return verifyIngestFromMhs(finder, mhs)
+}
 
+func verifyIngestFromMhs(finder *httpfinderclient.Client, mhs []multihash.Multihash) (*verifyIngestResult, error) {
+	result := &verifyIngestResult{}
 	mhsCount := len(mhs)
 	result.total = mhsCount
 	response, err := finder.FindBatch(context.Background(), mhs)


### PR DESCRIPTION
Implement a CLI command that gets the content of an advertisement from
a provider endpoint either via HTTP or over graphsync depending on the
given endpoint with option to print the entire list of multihashes.