### PR TITLE
Add CLI command to verify ingestion by getting ad directly from provider

### DIFF
--- a/cmd/provider/doc.go
+++ b/cmd/provider/doc.go
@@ -24,6 +24,7 @@ Usage:
 	   register           Register provider information with an indexer that trusts the provider
 	   remove, rm         Removes previously advertised multihashes by the provider.
 	   verify-ingest, vi  Verifies ingestion of multihashes to an indexer node from a Lotus miner, CAR file or a CARv2 Index
+	   list               Lists advertisements
 	   help, h            Shows a list of commands or help for one command
 
 	GLOBAL OPTIONS:

--- a/cmd/provider/internal/entries_iter.go
+++ b/cmd/provider/internal/entries_iter.go
@@ -47,7 +47,7 @@ func (d *EntriesIterator) Next() (multihash.Multihash, error) {
 	return d.chunkIter.Next()
 }
 
-func (d *EntriesIterator) Drain() ([]multihash.Multihash, int, error) {
+func (d *EntriesIterator) Drain() ([]multihash.Multihash, error) {
 	var mhs []multihash.Multihash
 	for {
 		mh, err := d.Next()
@@ -55,11 +55,18 @@ func (d *EntriesIterator) Drain() ([]multihash.Multihash, int, error) {
 			break
 		}
 		if err != nil {
-			return nil, d.chunkCount, err
+			return nil, err
 		}
 		mhs = append(mhs, mh)
 	}
-	return mhs, d.chunkCount, nil
+	return mhs, nil
+}
+
+//ChunkCount returns the number of current chunk in iteration.
+// This function returns the final count of entries chunk when iteration reaches its end, i.e.
+// calling EntriesIterator.Next returns io.EOF error.
+func (d *EntriesIterator) ChunkCount() int {
+	return d.chunkCount
 }
 
 func (s *sliceMhIterator) Next() (multihash.Multihash, error) {


### PR DESCRIPTION
Add `provider verify-ingest` option to get the advertisement by directly
connecting to a provider's grphsync endpoint and fetching either the
latest advertisement entries or entries belonging to a specific
advertisement CID.