### PR TITLE
Implement recursive ingest verification by walking the chain

### DIFF
--- a/cmd/provider/flags.go
+++ b/cmd/provider/flags.go
@@ -169,3 +169,15 @@ var (
 		Destination: &carZeroLengthAsEOFFlagValue,
 	}
 )
+
+var (
+	adEntriesRecurLimitFlagValue int64
+	adEntriesRecurLimitFlag      = &cli.Int64Flag{
+		Name:        "ad-entries-recursion-limit",
+		Aliases:     []string{"aerl"},
+		Usage:       "The maximum recursion depth when fetching advertisement entries chain.",
+		Value:       100,
+		DefaultText: "100 (set to '0' for unlimited)",
+		Destination: &adEntriesRecurLimitFlagValue,
+	}
+)

--- a/cmd/provider/internal/entries_iter.go
+++ b/cmd/provider/internal/entries_iter.go
@@ -55,7 +55,9 @@ func (d *EntriesIterator) Drain() ([]multihash.Multihash, error) {
 			break
 		}
 		if err != nil {
-			return nil, err
+			// Return what we have with error.
+			// This is used when err is datastore.ErrNotFound when recursion limit stopped the remaining entries to be synced.
+			return mhs, err
 		}
 		mhs = append(mhs, mh)
 	}


### PR DESCRIPTION
Add option to `verify-ingest` to walk the chain of advertisement from
either a given CID or head up to a configured limit, and for each
encountered advertisement verify ingest.

Add the ability to limit entries chain sync when it is too long along
with output to tell the CLI user of their existence.