### PR TITLE
Update the default topic name to be consistent with storetheindex

### DIFF
--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -39,7 +39,7 @@ var (
 			&cli.StringFlag{
 				Name:        "topic",
 				Usage:       "The topic on which index advertisements are published. Only needed if connecting to provider via Graphsync endpoint.",
-				Value:       "indexer/ingest",
+				Value:       "/indexer/ingest/mainnet",
 				Aliases:     []string{"t"},
 				Destination: &topic,
 			},

--- a/cmd/provider/verify_ingest.go
+++ b/cmd/provider/verify_ingest.go
@@ -202,7 +202,7 @@ Example output:
 				Name:        "topic",
 				Aliases:     []string{"t"},
 				Usage:       "The topic name on which advertisements are published by the provider. This Option only takes effect if source of multihashes is set to a provider.",
-				Value:       "indexer/ingest",
+				Value:       "/indexer/ingest/mainnet",
 				Destination: &topic,
 			},
 		},

--- a/config/ingest.go
+++ b/config/ingest.go
@@ -5,7 +5,7 @@ const (
 	defaultLinkCacheSize = 1024
 	// Multihashes are 128 bytes so 16384 redults in 2MB chunk when full.
 	defaultLinkedChunkSize = 16384
-	defaultPubSubTopic     = "indexer/ingest"
+	defaultPubSubTopic     = "/indexer/ingest/mainnet"
 )
 
 type PublisherKind string


### PR DESCRIPTION
`storetheindex` topic is updated to include network name. Make it
consistent here.