### PR TITLE
Automatically Build and attach binaries to published releases

### DIFF
--- a/.github/workflows/goreleaser-check.yml
+++ b/.github/workflows/goreleaser-check.yml
@@ -1,0 +1,23 @@
+name: Check GoReleaser Config
+on:
+  pull_request:
+    paths: [ '.goreleaser.yaml' ]
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.x"
+      - name: Check GoReleaser config
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: check

--- a/.github/workflows/releaser-bin.yml
+++ b/.github/workflows/releaser-bin.yml
@@ -1,0 +1,25 @@
+name: Binary Releaser
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  bin-releaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: "1.17.x"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 index-provider
 cmd/provider/provider
 ./provider
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,17 @@
+builds:
+  - main: ./provider
+    dir: cmd
+    binary: provider
+    goos:
+      - linux
+      - windows
+      - darwin
+    goarch:
+      - 'amd64'
+      - '386'
+release:
+  # Do not override manually written relase notes.
+  mode: keep-existing
+changelog:
+  # Do not generate changelog since for this project release notes are written manually.
+  skip: true


### PR DESCRIPTION
Use goreleaser to build and attach binaries for multiple platform to a
published release.

Add CI job to check goreleaser config for validity on change.