### PR TITLE
Fix RNG used by `testutil` to avoid intermittent test failures

### DIFF
--- a/server/admin/http/importcar_handler_test.go
+++ b/server/admin/http/importcar_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,6 +23,7 @@ import (
 )
 
 func Test_importCarHandler(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	wantMetadata, err := cardatatransfer.MetadataFromContextID(wantKey)
 	require.NoError(t, err)
@@ -47,7 +49,7 @@ func Test_importCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handle)
-	randCids, err := testutil.RandomCids(1)
+	randCids, err := testutil.RandomCids(rng, 1)
 	require.NoError(t, err)
 	wantCid := randCids[0]
 

--- a/server/admin/http/removecar_handler_test.go
+++ b/server/admin/http/removecar_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"io/ioutil"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -23,6 +24,7 @@ import (
 )
 
 func Test_removeCarHandler(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
 
@@ -36,8 +38,8 @@ func Test_removeCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handle)
-	wantCid := requireRandomCid(t)
-	requireMockPut(t, mockEng, wantKey, cs)
+	wantCid := requireRandomCid(t, rng)
+	requireMockPut(t, mockEng, wantKey, cs, rng)
 
 	mockEng.
 		EXPECT().
@@ -58,6 +60,7 @@ func Test_removeCarHandler(t *testing.T) {
 }
 
 func Test_removeCarHandlerFail(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
 	wantKey := []byte("lobster")
 	req := requireRemoveCarHttpRequestFromKey(t, wantKey)
 
@@ -71,7 +74,7 @@ func Test_removeCarHandlerFail(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handle)
-	requireMockPut(t, mockEng, wantKey, cs)
+	requireMockPut(t, mockEng, wantKey, cs, rng)
 
 	mockEng.
 		EXPECT().
@@ -156,10 +159,10 @@ func requireRemoveCarHttpRequest(t *testing.T, body io.Reader) *http.Request {
 	return req
 }
 
-func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []byte, cs *supplier.CarSupplier) {
+func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []byte, cs *supplier.CarSupplier, rng *rand.Rand) {
 	wantMetadata, err := cardatatransfer.MetadataFromContextID(key)
 	require.NoError(t, err)
-	wantCid := requireRandomCid(t)
+	wantCid := requireRandomCid(t, rng)
 
 	mockEng.
 		EXPECT().
@@ -169,8 +172,8 @@ func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []by
 	require.NoError(t, err)
 }
 
-func requireRandomCid(t *testing.T) cid.Cid {
-	randCids, err := testutil.RandomCids(1)
+func requireRandomCid(t *testing.T, rng *rand.Rand) cid.Cid {
+	randCids, err := testutil.RandomCids(rng, 1)
 	require.NoError(t, err)
 	return randCids[0]
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -38,14 +38,13 @@ func GenerateCids(n int) []cid.Cid {
 	return cids
 }
 
-func RandomCids(n int) ([]cid.Cid, error) {
-	prng := rand.New(rand.NewSource(time.Now().UnixNano()))
+func RandomCids(rng *rand.Rand, n int) ([]cid.Cid, error) {
 	prefix := schema.Linkproto.Prefix
 
 	cids := make([]cid.Cid, n)
 	for i := 0; i < n; i++ {
 		b := make([]byte, 10*n)
-		prng.Read(b)
+		rng.Read(b)
 		c, err := prefix.Sum(b)
 		if err != nil {
 			return nil, err
@@ -55,14 +54,13 @@ func RandomCids(n int) ([]cid.Cid, error) {
 	return cids, nil
 }
 
-func RandomMultihashes(n int) ([]multihash.Multihash, error) {
-	prng := rand.New(rand.NewSource(time.Now().UnixNano()))
+func RandomMultihashes(rng *rand.Rand, n int) ([]multihash.Multihash, error) {
 	prefix := schema.Linkproto.Prefix
 
 	mhashes := make([]multihash.Multihash, n)
 	for i := 0; i < n; i++ {
 		b := make([]byte, 10*n)
-		prng.Read(b)
+		rng.Read(b)
 		c, err := prefix.Sum(b)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The `testutil` functions that use RNG, were creating a new instance of it
seeded with current unix time. This causes two main issues: 1)
randomness in tests is not deterministic, which makes reproducing
intermittent test failures difficult. 2) the implementation of current
system nano time is platform-specific and when tests are run
concurrently this can cause issues with duplicate generated values
across gorutines that expect unique values for testing purposes.

Fix this by requiring RNG in `testutil` and instantiate one explicitly
with a fixed seed in each test.