### PR TITLE
Delay republishing last advertisement notification on start

### DIFF
--- a/config/ingest.go
+++ b/config/ingest.go
@@ -1,11 +1,14 @@
 package config
 
+import "time"
+
 const (
 	// Keep 1024 chunks in cache; keeps 256MiB if chunks are 0.25MiB.
 	defaultLinkCacheSize = 1024
 	// Multihashes are 128 bytes so 16384 results in 0.25MiB chunk when full.
-	defaultLinkedChunkSize = 16384
-	defaultPubSubTopic     = "/indexer/ingest/mainnet"
+	defaultLinkedChunkSize   = 16384
+	defaultPubSubTopic       = "/indexer/ingest/mainnet"
+	defaultStartPublishDelay = Duration(time.Minute)
 )
 
 type PublisherKind string
@@ -36,16 +39,23 @@ type Ingest struct {
 
 	// PublisherKind specifies which legs.Publisher implementation to use.
 	PublisherKind PublisherKind
+
+	// StartPublishDelay specifies how long to wait, after startup, to
+	// re-publish the latest advertisement notification.  This delay gives time
+	// to connect to other nodes and establish gossip mesh before sending
+	// pubsub advertisement notification message.
+	StartPublishDelay Duration
 }
 
 // NewIngest instantiates a new Ingest configuration with default values.
 func NewIngest() Ingest {
 	return Ingest{
-		LinkCacheSize:   defaultLinkCacheSize,
-		LinkedChunkSize: defaultLinkedChunkSize,
-		PubSubTopic:     defaultPubSubTopic,
-		HttpPublisher:   NewHttpPublisher(),
-		PublisherKind:   DTSyncPublisherKind,
+		LinkCacheSize:     defaultLinkCacheSize,
+		LinkedChunkSize:   defaultLinkedChunkSize,
+		PubSubTopic:       defaultPubSubTopic,
+		HttpPublisher:     NewHttpPublisher(),
+		PublisherKind:     DTSyncPublisherKind,
+		StartPublishDelay: defaultStartPublishDelay,
 	}
 }
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -73,6 +73,7 @@ type Engine struct {
 	purgeLinkCache bool
 	// linkCacheSize is the capacity of the link cache LRU
 	linkCacheSize int
+	startPubDelay time.Duration
 
 	// cb is the callback used in the linkSystem
 	cb   provider.Callback
@@ -126,6 +127,7 @@ func New(ingestCfg config.Ingest, privKey crypto.PrivKey, dt dt.Manager, h host.
 		linkedChunkSize: ingestCfg.LinkedChunkSize,
 		purgeLinkCache:  ingestCfg.PurgeLinkCache,
 		linkCacheSize:   ingestCfg.LinkCacheSize,
+		startPubDelay:   time.Duration(ingestCfg.StartPublishDelay),
 
 		addrs:            retAddrs,
 		httpPublisherCfg: &ingestCfg.HttpPublisher,
@@ -193,7 +195,7 @@ func (e *Engine) Start(ctx context.Context) error {
 		// Delay re-publishing latest advertisement notice until there has been
 		// some time to bootstrap to other nodes.
 		select {
-		case <-time.After(30 * time.Second):
+		case <-time.After(e.startPubDelay):
 		case <-ctx.Done():
 			return
 		}


### PR DESCRIPTION
The delay is needed to give some time to connect to othernodes. Otherwise, if not connected to other nodes, the notification will never go out.

An alternative to this PR is to have any applications, that use this provider, call `engine.PublishLatest` sometime after connecting to other node(s).