### PR TITLE
Fix typo in install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ and cannot be installed directly via `go install`
 
 ```shell
 git clone https://github.com/filecoin-project/index-provider
-cd cmd
-go insrtall ./provider
+cd index-provider && cd cmd
+go install ./provider
 ```
 
 Alternatively, download the executables directly from


### PR DESCRIPTION
Fixed typo, and also clarified that you need to cd into the index-provider folder before "cd cmd"