### PR TITLE
Handle `NoEntries` cid gracefully and improve cli output

### DIFF
--- a/cmd/provider/internal/client_store.go
+++ b/cmd/provider/internal/client_store.go
@@ -40,6 +40,10 @@ type (
 	}
 )
 
+func (a *Advertisement) HasEntries() bool {
+	return a.Entries.IsPresent()
+}
+
 func newProviderClientStore() *ProviderClientStore {
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
 	lsys := cidlink.DefaultLinkSystem()

--- a/cmd/provider/internal/options.go
+++ b/cmd/provider/internal/options.go
@@ -1,0 +1,39 @@
+package internal
+
+import "github.com/ipld/go-ipld-prime/traversal/selector"
+
+type (
+	Option func(*options) error
+
+	options struct {
+		entriesRecurLimit selector.RecursionLimit
+		topic             string
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	opts := &options{
+		entriesRecurLimit: selector.RecursionLimitNone(),
+		topic:             "/indexer/ingest/mainnet",
+	}
+	for _, apply := range o {
+		if err := apply(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+func WithTopic(topic string) Option {
+	return func(o *options) error {
+		o.topic = topic
+		return nil
+	}
+}
+
+func WithEntriesRecursionLimit(limit selector.RecursionLimit) Option {
+	return func(o *options) error {
+		o.entriesRecurLimit = limit
+		return nil
+	}
+}


### PR DESCRIPTION
When encountering `NoEntries` CID, do not attempt to traverse it in
`provider` CLI.

Do not traverse entries of a removal advertisement even if a CID is
present. Instead, print useufl messages to signal such cases.

Improve output for human readability.

Fixes #179