### PR TITLE
Do not resolve `schema.NoEntries` CID

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -453,10 +453,6 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, metad
 		// that advertisement has no entries.
 		cidsLnk = schema.NoEntries
 
-		// To delete specific index values, provide the CID link to the
-		// content entries to delete.  The indexer will fetch these entries and
-		// delete indexes for the content in each entry chunk.
-
 		// The advertisement still requires a valid metadata even though
 		// metadata is not used for removal.  Create a valid empty metadata.
 		metadata = stiapi.Metadata{


### PR DESCRIPTION
Given that the indexer protocol is now changed to only support
"remove all" advertisements, adjust code comments to remove suggestions
that explicit removal of multihashes is supported.

Do not attempt to resolve entries link that points to `schema.NoEntries`
 special CID.

 Add tests that assert both add and remove advertisements are
 resolvable. But when content is removed, entry chunk corresponding to
 earlier add advertisement for that content is no longer found.

Relates to: https://github.com/filecoin-project/storetheindex/pull/225

Fixes #174