### PR TITLE
Use legs subscriber to abstract out the dtsync vs httpsync

### DIFF
--- a/cmd/provider/internal/client_store.go
+++ b/cmd/provider/internal/client_store.go
@@ -70,7 +70,7 @@ func newProviderClientStore() *ProviderClientStore {
 }
 
 func (s *ProviderClientStore) getEntriesChunk(ctx context.Context, target cid.Cid) (cid.Cid, []multihash.Multihash, error) {
-	n, err := s.LinkSystem.Load(linking.LinkContext{}, cidlink.Link{Cid: target}, schema.Type.EntryChunk)
+	n, err := s.LinkSystem.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: target}, schema.Type.EntryChunk)
 	if err != nil {
 		return cid.Undef, nil, err
 	}

--- a/cmd/provider/internal/entries_iter.go
+++ b/cmd/provider/internal/entries_iter.go
@@ -52,7 +52,7 @@ func (d *EntriesIterator) Next() (multihash.Multihash, error) {
 		return d.chunkIter.Next()
 	}
 
-	if isPresent(d.next) {
+	if !isPresent(d.next) {
 		return nil, io.EOF
 	}
 

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -82,11 +82,6 @@ func toProviderClient(addrStr string, topic string) (internal.ProviderClient, er
 		return nil, err
 	}
 	addrInfo := addrInfos[0]
-	for _, p := range addrInfo.Addrs[0].Protocols() {
-		if p.Code == multiaddr.P_HTTP || p.Code == multiaddr.P_HTTPS {
-			return internal.NewHttpProviderClient(addrInfo)
-		}
-	}
 
 	if topic == "" {
 		return nil, errors.New("topic must be configured when graphsync endpoint is specified")
@@ -103,7 +98,7 @@ func toProviderClient(addrStr string, topic string) (internal.ProviderClient, er
 		entRecurLim = selector.RecursionLimitDepth(adEntriesRecurLimitFlagValue)
 	}
 
-	return internal.NewGraphSyncProviderClient(addrInfo, internal.WithTopic(topic), internal.WithEntriesRecursionLimit(entRecurLim))
+	return internal.NewProviderClient(addrInfo, internal.WithTopic(topic), internal.WithEntriesRecursionLimit(entRecurLim))
 }
 
 func doGetAdvertisements(cctx *cli.Context) error {


### PR DESCRIPTION
...In list.

I was testing this on an http endpoint and it was failing. I simplified the two flows into a single flow using the legs subscriber abstraction.

I also fixed a bug that prevented entries from showing in the list command.
