### PR TITLE
Print ad chain stats and retry when syncing ads

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/libp2p/go-libp2p v0.18.0-rc3
 	github.com/libp2p/go-libp2p-core v0.14.0
 	github.com/mitchellh/go-homedir v1.1.0
+	github.com/montanaflynn/stats v0.6.6
 	github.com/multiformats/go-multiaddr v0.5.0
 	github.com/multiformats/go-multicodec v0.4.1
 	github.com/multiformats/go-multihash v0.1.0

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -1139,6 +1139,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJ
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/montanaflynn/stats v0.6.6 h1:Duep6KMIDpY4Yo11iFsvyqJDyfzLF9+sndUKT+v64GQ=
+github.com/montanaflynn/stats v0.6.6/go.mod h1:etXPPgVO6n31NxCd9KQUMvCM+ve0ruNzt6R8Bnaayow=
 github.com/mr-tron/base58 v1.1.0/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.1/go.mod h1:xcD2VGqlgYjBdcBLw+TuYLr8afG+Hj8g2eTVqeSzSU8=
 github.com/mr-tron/base58 v1.1.2/go.mod h1:BinMc/sQntlIE1frQmRFPUoPA1Zkr8VRgBdjWI2mNwc=

--- a/cmd/provider/internal/ad_stats.go
+++ b/cmd/provider/internal/ad_stats.go
@@ -1,0 +1,117 @@
+package internal
+
+import (
+	"errors"
+
+	"github.com/ipfs/go-datastore"
+	"github.com/montanaflynn/stats"
+	"github.com/multiformats/go-multihash"
+)
+
+type (
+	Sampler func() bool
+
+	AdStats struct {
+		sampler                 Sampler
+		NonRmCount              int
+		RmCount                 int
+		AdNoLongerProvidedCount int
+
+		ctxIDRm map[string]bool
+		samples []*AdSample
+
+		mhCountDist    []interface{}
+		chunkCountDist []interface{}
+	}
+
+	AdSample struct {
+		IsRemove         bool
+		NoLongerProvided bool
+		ctxID            string
+		PartiallySynced  bool
+		SyncErr          error
+		ChunkCount       int
+		MhCount          int
+		MhSample         []multihash.Multihash
+	}
+)
+
+func NewAdStats(s Sampler) *AdStats {
+	if s == nil {
+		s = func() bool { return true }
+	}
+	return &AdStats{
+		ctxIDRm: make(map[string]bool),
+		sampler: s,
+	}
+}
+
+func (a *AdStats) Sample(ad *Advertisement) *AdSample {
+	sample := &AdSample{
+		IsRemove: ad.IsRemove,
+		ctxID:    string(ad.ContextID),
+	}
+
+	if sample.IsRemove {
+		a.RmCount++
+		a.ctxIDRm[sample.ctxID] = true
+
+		a.samples = append(a.samples, sample)
+		return sample
+	}
+
+	a.NonRmCount++
+	removed, seen := a.ctxIDRm[sample.ctxID]
+	if seen && removed {
+		sample.NoLongerProvided = true
+		a.AdNoLongerProvidedCount++
+
+		a.samples = append(a.samples, sample)
+		return sample
+	}
+
+	a.ctxIDRm[sample.ctxID] = false
+	if !ad.HasEntries() {
+		a.samples = append(a.samples, sample)
+		return sample
+	}
+
+	allMhs, err := ad.Entries.Drain()
+	if err != nil {
+		sample.PartiallySynced = true
+		// Most likely caused by entries recursion limit reached.
+		if err == datastore.ErrNotFound {
+			err = errors.New("recursion limit reached")
+		}
+		sample.SyncErr = err
+	}
+	sample.MhCount = len(allMhs)
+	sample.ChunkCount = ad.Entries.ChunkCount()
+
+	for _, mh := range allMhs {
+		if a.sampler() {
+			sample.MhSample = append(sample.MhSample, mh)
+		}
+	}
+	a.samples = append(a.samples, sample)
+
+	a.mhCountDist = append(a.mhCountDist, sample.MhCount)
+	a.chunkCountDist = append(a.chunkCountDist, sample.ChunkCount)
+	return sample
+}
+
+func (a *AdStats) TotalAdCount() int {
+	return a.NonRmCount + a.RmCount
+}
+
+func (a *AdStats) UniqueContextIDCount() int {
+	return len(a.ctxIDRm)
+}
+
+func (a *AdStats) NonRmMhStats() stats.Float64Data {
+	return stats.LoadRawData(a.mhCountDist)
+}
+
+func (a *AdStats) NonRmChunkStats() stats.Float64Data {
+	return stats.LoadRawData(a.chunkCountDist)
+}

--- a/cmd/provider/internal/client.go
+++ b/cmd/provider/internal/client.go
@@ -6,7 +6,10 @@ import (
 
 	"github.com/filecoin-project/go-legs"
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	selectorbuilder "github.com/ipld/go-ipld-prime/traversal/selector/builder"
@@ -14,19 +17,21 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
+var log = logging.Logger("client")
+
 type (
 	ProviderClient interface {
 		GetAdvertisement(ctx context.Context, id cid.Cid) (*Advertisement, error)
 		Close() error
 	}
 	providerClient struct {
+		*options
 		sub *legs.Subscriber
 
 		store     *ProviderClientStore
 		publisher peer.AddrInfo
 
-		adSel  ipld.Node
-		entSel ipld.Node
+		adSel ipld.Node
 	}
 )
 
@@ -54,23 +59,26 @@ func NewProviderClient(provAddr peer.AddrInfo, o ...Option) (ProviderClient, err
 			efsb.Insert("PreviousID", ssb.ExploreRecursiveEdge())
 		})).Node()
 
-	entSel := ssb.ExploreRecursive(opts.entriesRecurLimit, ssb.ExploreFields(
-		func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
-			efsb.Insert("Next", ssb.ExploreRecursiveEdge())
-		})).Node()
-
 	return &providerClient{
+		options:   opts,
 		sub:       sub,
 		publisher: provAddr,
 		store:     store,
 		adSel:     adSel,
-		entSel:    entSel,
 	}, nil
+}
+
+func selectEntriesWithLimit(limit selector.RecursionLimit) datamodel.Node {
+	ssb := selectorbuilder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+	return ssb.ExploreRecursive(limit, ssb.ExploreFields(
+		func(efsb selectorbuilder.ExploreFieldsSpecBuilder) {
+			efsb.Insert("Next", ssb.ExploreRecursiveEdge())
+		})).Node()
 }
 
 func (p *providerClient) GetAdvertisement(ctx context.Context, id cid.Cid) (*Advertisement, error) {
 	// Sync the advertisement without entries first.
-	id, err := p.sub.Sync(ctx, p.publisher.ID, id, p.adSel, p.publisher.Addrs[0])
+	id, err := p.syncAdWithRetry(ctx, id)
 	if err != nil {
 		return nil, err
 	}
@@ -83,11 +91,69 @@ func (p *providerClient) GetAdvertisement(ctx context.Context, id cid.Cid) (*Adv
 
 	// Only sync its entries recursively if it is not a removal advertisement and has entries.
 	if !ad.IsRemove && ad.HasEntries() {
-		_, err = p.sub.Sync(ctx, p.publisher.ID, ad.Entries.root, p.entSel, p.publisher.Addrs[0])
+		_, err = p.syncEntriesWithRetry(ctx, ad.Entries.root)
 	}
 
 	// Return the partially synced advertisement useful for output to client.
 	return ad, err
+}
+
+func (p *providerClient) syncAdWithRetry(ctx context.Context, id cid.Cid) (cid.Cid, error) {
+	var attempt uint64
+	for {
+		id, err := p.sub.Sync(ctx, p.publisher.ID, id, p.adSel, p.publisher.Addrs[0])
+		if err == nil {
+			return id, nil
+		}
+		if attempt > p.maxSyncRetry {
+			log.Errorw("Reached maximum retry attempt while syncing ad", "cid", id, "attempt", attempt, "err", err)
+			return cid.Undef, err
+		}
+		attempt++
+		log.Infow("retrying ad sync", "attempt", attempt, "err", err)
+		time.Sleep(p.syncRetryBackoff)
+	}
+}
+
+func (p *providerClient) syncEntriesWithRetry(ctx context.Context, id cid.Cid) (cid.Cid, error) {
+	var attempt uint64
+	recurLimit := p.entriesRecurLimit
+	for {
+		sel := selectEntriesWithLimit(recurLimit)
+		_, err := p.sub.Sync(ctx, p.publisher.ID, id, sel, p.publisher.Addrs[0])
+		if err == nil {
+			return id, nil
+		}
+		if attempt > p.maxSyncRetry {
+			log.Errorw("Reached maximum retry attempt while syncing entries", "cid", id, "attempt", attempt, "err", err)
+			return cid.Undef, err
+		}
+		nextMissing, visitedDepth, present := p.findNextMissingChunkLink(ctx, id)
+		if !present {
+			return id, nil
+		}
+		id = nextMissing
+		attempt++
+		remainingLimit := recurLimit.Depth() - visitedDepth
+		recurLimit = selector.RecursionLimitDepth(remainingLimit)
+		log.Infow("Retrying entries sync", "recurLimit", remainingLimit, "attempt", attempt, "err", err)
+		time.Sleep(p.syncRetryBackoff)
+	}
+}
+
+func (p *providerClient) findNextMissingChunkLink(ctx context.Context, next cid.Cid) (cid.Cid, int64, bool) {
+	var depth int64
+	for {
+		if !isPresent(next) {
+			return cid.Undef, depth, false
+		}
+		c, err := p.store.getNextChunkLink(ctx, next)
+		if err == datastore.ErrNotFound {
+			return next, depth, true
+		}
+		next = c
+		depth++
+	}
 }
 
 func (p *providerClient) Close() error {

--- a/cmd/provider/internal/client_store.go
+++ b/cmd/provider/internal/client_store.go
@@ -69,6 +69,24 @@ func newProviderClientStore() *ProviderClientStore {
 	}
 }
 
+func (s *ProviderClientStore) getNextChunkLink(ctx context.Context, target cid.Cid) (cid.Cid, error) {
+	n, err := s.LinkSystem.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: target}, schema.Type.EntryChunk)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	node := n.(schema.EntryChunk)
+	if node.FieldNext().IsAbsent() || node.FieldNext().IsNull() {
+		return cid.Undef, nil
+	}
+
+	lnk, err := node.FieldNext().AsNode().AsLink()
+	if err != nil {
+		return cid.Undef, err
+	}
+	return lnk.(cidlink.Link).Cid, nil
+}
+
 func (s *ProviderClientStore) getEntriesChunk(ctx context.Context, target cid.Cid) (cid.Cid, []multihash.Multihash, error) {
 	n, err := s.LinkSystem.Load(linking.LinkContext{Ctx: ctx}, cidlink.Link{Cid: target}, schema.Type.EntryChunk)
 	if err != nil {

--- a/cmd/provider/internal/ingest_verifier.go
+++ b/cmd/provider/internal/ingest_verifier.go
@@ -1,0 +1,102 @@
+package internal
+
+import (
+	"context"
+	"fmt"
+
+	httpfinderclient "github.com/filecoin-project/storetheindex/api/v0/finder/client/http"
+	"github.com/filecoin-project/storetheindex/api/v0/finder/model"
+	"github.com/multiformats/go-multihash"
+)
+
+const verifyChunkSize = 4096
+
+type VerifyIngestResult struct {
+	TotalMhChecked   int
+	ProviderMismatch int
+	Present          int
+	Absent           int
+	FailedToVerify   int
+	Errs             []error
+	AbsentMhs        []multihash.Multihash
+}
+
+func (r *VerifyIngestResult) PassedVerification() bool {
+	return r.Present == r.TotalMhChecked
+}
+
+func (r *VerifyIngestResult) Add(other *VerifyIngestResult) {
+	r.TotalMhChecked += other.TotalMhChecked
+	r.ProviderMismatch += other.ProviderMismatch
+	r.Present += other.Present
+	r.Absent += other.Absent
+	r.FailedToVerify += other.FailedToVerify
+	r.Errs = append(r.Errs, other.Errs...)
+	r.AbsentMhs = append(r.AbsentMhs, other.AbsentMhs...)
+}
+
+func VerifyIngestFromMhs(finder *httpfinderclient.Client, wantProvID string, mhs []multihash.Multihash) (*VerifyIngestResult, error) {
+	aggResult := &VerifyIngestResult{}
+	for len(mhs) >= verifyChunkSize {
+		result, err := doVerifyIngest(finder, wantProvID, mhs[:verifyChunkSize])
+		if err != nil {
+			return nil, err
+		}
+		aggResult.Add(result)
+		mhs = mhs[verifyChunkSize:]
+	}
+	if len(mhs) != 0 {
+		result, err := doVerifyIngest(finder, wantProvID, mhs)
+		if err != nil {
+			return nil, err
+		}
+		aggResult.Add(result)
+	}
+	return aggResult, nil
+}
+
+func doVerifyIngest(finder *httpfinderclient.Client, wantProvID string, mhs []multihash.Multihash) (*VerifyIngestResult, error) {
+	result := &VerifyIngestResult{}
+	mhsCount := len(mhs)
+	result.TotalMhChecked = mhsCount
+	response, err := finder.FindBatch(context.Background(), mhs)
+	if err != nil {
+		result.FailedToVerify = mhsCount
+		err = fmt.Errorf("failed to connect to indexer: %w", err)
+		result.Errs = append(result.Errs, err)
+		return result, nil
+	}
+
+	if len(response.MultihashResults) == 0 {
+		result.Absent = mhsCount
+		return result, nil
+	}
+
+	resultsByMh := make(map[string]model.MultihashResult, len(response.MultihashResults))
+	for _, mr := range response.MultihashResults {
+		resultsByMh[mr.Multihash.String()] = mr
+	}
+
+	for _, mh := range mhs {
+		gotResult, ok := resultsByMh[mh.String()]
+		if !ok || len(gotResult.ProviderResults) == 0 {
+			result.Absent++
+			result.AbsentMhs = append(result.AbsentMhs, mh)
+			continue
+		}
+
+		var provMatched bool
+		for _, p := range gotResult.ProviderResults {
+			gotProvID := p.Provider.ID.String()
+			if gotProvID == wantProvID {
+				result.Present++
+				provMatched = true
+				break
+			}
+		}
+		if !provMatched {
+			result.ProviderMismatch++
+		}
+	}
+	return result, nil
+}

--- a/cmd/provider/internal/options.go
+++ b/cmd/provider/internal/options.go
@@ -1,6 +1,10 @@
 package internal
 
-import "github.com/ipld/go-ipld-prime/traversal/selector"
+import (
+	"time"
+
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+)
 
 type (
 	Option func(*options) error
@@ -8,6 +12,8 @@ type (
 	options struct {
 		entriesRecurLimit selector.RecursionLimit
 		topic             string
+		maxSyncRetry      uint64
+		syncRetryBackoff  time.Duration
 	}
 )
 
@@ -15,6 +21,8 @@ func newOptions(o ...Option) (*options, error) {
 	opts := &options{
 		entriesRecurLimit: selector.RecursionLimitNone(),
 		topic:             "/indexer/ingest/mainnet",
+		maxSyncRetry:      10,
+		syncRetryBackoff:  500 * time.Millisecond,
 	}
 	for _, apply := range o {
 		if err := apply(opts); err != nil {
@@ -24,13 +32,35 @@ func newOptions(o ...Option) (*options, error) {
 	return opts, nil
 }
 
-func WithTopic(topic string) Option {
+// WithSyncRetryBackoff sets the length of time to wait before retrying a faild sync.
+// Defaults to 500ms if unset.
+func WithSyncRetryBackoff(d time.Duration) Option {
+	return func(o *options) error {
+		o.syncRetryBackoff = d
+		return nil
+	}
+}
+
+// WithMaxSyncRetry sets the maximum number of times to retry a failed sync.
+// Defaults to 10 if unset.
+func WithMaxSyncRetry(r uint64) Option {
+	return func(o *options) error {
+		o.maxSyncRetry = r
+		return nil
+	}
+}
+
+// WithTopicName sets the topic name on which the provider announces advertised content.
+// Defaults to '/indexer/ingest/mainnet'.
+func WithTopicName(topic string) Option {
 	return func(o *options) error {
 		o.topic = topic
 		return nil
 	}
 }
 
+// WithEntriesRecursionLimit sets the recursion limit when syncing advertisement entries chain.
+// Defaults to no limit.
 func WithEntriesRecursionLimit(limit selector.RecursionLimit) Option {
 	return func(o *options) error {
 		o.entriesRecurLimit = limit

--- a/cmd/provider/list.go
+++ b/cmd/provider/list.go
@@ -98,7 +98,7 @@ func toProviderClient(addrStr string, topic string) (internal.ProviderClient, er
 		entRecurLim = selector.RecursionLimitDepth(adEntriesRecurLimitFlagValue)
 	}
 
-	return internal.NewProviderClient(addrInfo, internal.WithTopic(topic), internal.WithEntriesRecursionLimit(entRecurLim))
+	return internal.NewProviderClient(addrInfo, internal.WithTopicName(topic), internal.WithEntriesRecursionLimit(entRecurLim))
 }
 
 func doGetAdvertisements(cctx *cli.Context) error {

--- a/cmd/provider/printer.go
+++ b/cmd/provider/printer.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/filecoin-project/index-provider/cmd/provider/internal"
+)
+
+func printVerificationResult(r *internal.VerifyIngestResult) {
+	fmt.Println()
+	fmt.Println("Verification result:")
+	fmt.Printf("  # failed to verify:                   %d\n", r.FailedToVerify)
+	fmt.Printf("  # unindexed:                          %d\n", r.Absent)
+	fmt.Printf("  # indexed with another provider ID:   %d\n", r.ProviderMismatch)
+	fmt.Printf("  # indexed with expected provider ID:  %d\n", r.Present)
+	fmt.Println("--------------------------------------------")
+	fmt.Printf("total Multihashes checked:              %d\n", r.TotalMhChecked)
+	fmt.Println()
+	fmt.Printf("sampling probability:                   %.2f\n", samplingProb)
+	fmt.Printf("RNG seed:                               %d\n", rngSeed)
+	fmt.Println()
+
+	if printUnindexedMhs && len(r.AbsentMhs) != 0 {
+		fmt.Println("Un-indexed Multihash(es):")
+		for _, mh := range r.AbsentMhs {
+			fmt.Printf("  %s\n", mh.B58String())
+		}
+		fmt.Println()
+	}
+
+	if r.TotalMhChecked == 0 {
+		fmt.Println("⚠️ Inconclusive; no multihashes were verified.")
+	} else if r.PassedVerification() {
+		fmt.Println("🎉 Passed verification check.")
+	} else {
+		fmt.Println("❌ Failed verification check.")
+	}
+
+	if len(r.Errs) != 0 {
+		fmt.Println("Verification Error(s):")
+		for _, err := range r.Errs {
+			fmt.Printf("  %s\n", err)
+		}
+		fmt.Println()
+	}
+}
+
+func printAdStats(stats *internal.AdStats) {
+	fmt.Println()
+	fmt.Println("Advertisement chain stats:")
+	fmt.Printf("  # rm ads:                             %d\n", stats.RmCount)
+	fmt.Printf("  # non-rm ads:                         %d\n", stats.NonRmCount)
+	fmt.Printf("     # of which had ctx id removed:     %d\n", stats.AdNoLongerProvidedCount)
+	fmt.Printf("  # unique context IDs:                 %d\n", stats.UniqueContextIDCount())
+
+	mhStats := stats.NonRmMhStats()
+	sum, _ := mhStats.Sum()
+	max, _ := mhStats.Max()
+	min, _ := mhStats.Min()
+	mean, _ := mhStats.Mean()
+	std, _ := mhStats.StandardDeviation()
+	fmt.Printf("  # max mhs per ad:                     %.0f\n", max)
+	fmt.Printf("  # min mhs per ad:                     %.0f\n", min)
+	fmt.Printf("  # mean ± std mhs per ad:              %.2f ± %.2f\n", mean, std)
+
+	cStats := stats.NonRmChunkStats()
+	cSum, _ := cStats.Sum()
+	cMax, _ := cStats.Max()
+	cMin, _ := cStats.Min()
+	cMean, _ := cStats.Mean()
+	cStd, _ := cStats.StandardDeviation()
+	fmt.Printf("  # max chunks per ad:                  %.0f\n", cMax)
+	fmt.Printf("  # min chunks per ad:                  %.0f\n", cMin)
+	fmt.Printf("  # mean ± std chunks per ad:           %.2f ± %.2f\n", cMean, cStd)
+	fmt.Println("--------------------------------------------")
+	fmt.Printf("total ads:                              %d\n", stats.TotalAdCount())
+	fmt.Printf("total mhs:                              %.0f\n", sum)
+	fmt.Printf("total chunks:                           %.0f\n", cSum)
+	fmt.Println()
+}


### PR DESCRIPTION
Add functionality to print statistics about the walked advertisement
chain, such as: total removal and non-removal ads, unique context ID
count, distribution of multihashes and chunks over advertisements, etc.

Add logic to retry syncing of ad and its entries, resuming from the last
successfully synced node in DAG.

Restructure verification logic to make command main package less
cluttered.