### PR TITLE
Re-implement engine tests and re-enable all tests

### DIFF
--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.14.0
-	github.com/filecoin-project/go-legs v0.3.7
+	github.com/filecoin-project/go-legs v0.3.8
 	github.com/filecoin-project/index-provider v0.2.1
 	github.com/filecoin-project/storetheindex v0.3.5
 	github.com/ipfs/go-cid v0.1.0

--- a/cmd/go.sum
+++ b/cmd/go.sum
@@ -213,8 +213,9 @@ github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.7 h1:yfm7fx+iy1nPtgPEQ6kQjvhoJOVbXide50STYdy+yos=
 github.com/filecoin-project/go-legs v0.3.7/go.mod h1:pgekGm8/gKY5zCtQ/qGAoSjGP92wTLFqpO3GPHeu8YU=
+github.com/filecoin-project/go-legs v0.3.8 h1:HDhunjC+E5g3s47zUQY/YnDveatOXWJyfK519jdKhOA=
+github.com/filecoin-project/go-legs v0.3.8/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
@@ -1461,8 +1462,9 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20200810223238-211df3b9e24c/go.mod h1:f
 github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200826160007-0b9f6c5fb163/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831 h1:9blPRrm7ebDqDm6nHXXzCSru+sp20gcA3CLu+G/kHUc=
 github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14 h1:vo2wkP2ceHyGyZwFFtAabpot03EeSxxwAe57pOI9E/4=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=

--- a/engine/engine_api_test.go
+++ b/engine/engine_api_test.go
@@ -1,0 +1,39 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/filecoin-project/index-provider/engine/chunker"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/stretchr/testify/require"
+)
+
+// Host returns the host on which the engine is started, exposed for testing purposes only.
+func (e *Engine) Host() host.Host {
+	return e.h
+}
+
+// Chunker returns the entries chunker used by the engine, exposed for testing purposes only.
+func (e *Engine) Chunker() *chunker.CachedEntriesChunker {
+	return e.entriesChunker
+}
+
+// Key returns the engine's private key, exposed for testing purposes only.
+func (e *Engine) Key() crypto.PrivKey {
+	return e.key
+}
+
+// LinkSystem returns the engine's linksystem, exposed for testing purposes only.
+func (e *Engine) LinkSystem() *ipld.LinkSystem {
+	return &e.lsys
+}
+
+func Test_EmptyConfigSetsDefaults(t *testing.T) {
+	engine, err := New()
+	require.NoError(t, err)
+	require.True(t, engine.entChunkSize > 0)
+	require.True(t, engine.entCacheCap > 0)
+	require.True(t, engine.pubTopicName != "")
+}

--- a/engine/slicemhiter_test.go
+++ b/engine/slicemhiter_test.go
@@ -1,0 +1,24 @@
+package engine_test
+
+import (
+	"io"
+
+	provider "github.com/filecoin-project/index-provider"
+	mh "github.com/multiformats/go-multihash"
+)
+
+var _ provider.MultihashIterator = (*sliceMhIterator)(nil)
+
+type sliceMhIterator struct {
+	mhs    []mh.Multihash
+	offset int
+}
+
+func (s *sliceMhIterator) Next() (mh.Multihash, error) {
+	if s.offset < len(s.mhs) {
+		next := s.mhs[s.offset]
+		s.offset++
+		return next, nil
+	}
+	return nil, io.EOF
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.14.0
-	github.com/filecoin-project/go-legs v0.3.7
+	github.com/filecoin-project/go-legs v0.3.8
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/storetheindex v0.3.5
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
@@ -27,6 +27,6 @@ require (
 	github.com/multiformats/go-multicodec v0.4.1
 	github.com/multiformats/go-multihash v0.1.0
 	github.com/stretchr/testify v1.7.0
-	github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831
+	github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1
 )

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,9 @@ github.com/filecoin-project/go-ds-versioning v0.0.0-20211206185234-508abd7c2aff/
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.8/go.mod h1:IagNfTdFuX4057kla43PjRCn3yBuUiZgIxuA0hTUamY=
-github.com/filecoin-project/go-legs v0.3.7 h1:yfm7fx+iy1nPtgPEQ6kQjvhoJOVbXide50STYdy+yos=
 github.com/filecoin-project/go-legs v0.3.7/go.mod h1:pgekGm8/gKY5zCtQ/qGAoSjGP92wTLFqpO3GPHeu8YU=
+github.com/filecoin-project/go-legs v0.3.8 h1:HDhunjC+E5g3s47zUQY/YnDveatOXWJyfK519jdKhOA=
+github.com/filecoin-project/go-legs v0.3.8/go.mod h1:FroH5LQUTfYzs8huA4PjW8spDF691uvK8uk9YAfDa78=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe h1:dF8u+LEWeIcTcfUcCf3WFVlc81Fr2JKg8zPzIbBDKDw=
@@ -1446,8 +1447,9 @@ github.com/whyrusleeping/cbor-gen v0.0.0-20200810223238-211df3b9e24c/go.mod h1:f
 github.com/whyrusleeping/cbor-gen v0.0.0-20200812213548-958ddffe352c/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20200826160007-0b9f6c5fb163/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/cbor-gen v0.0.0-20210219115102-f37d292932f2/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
-github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831 h1:9blPRrm7ebDqDm6nHXXzCSru+sp20gcA3CLu+G/kHUc=
 github.com/whyrusleeping/cbor-gen v0.0.0-20220224212727-7a699437a831/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14 h1:vo2wkP2ceHyGyZwFFtAabpot03EeSxxwAe57pOI9E/4=
+github.com/whyrusleeping/cbor-gen v0.0.0-20220302191723-37c43cae8e14/go.mod h1:fgkXqYy7bV2cFeIEOkVTZS/WjXARfBqSH6Q2qHL33hQ=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f h1:jQa4QT2UP9WYv2nzyawpKMOCl+Z/jW7djv2/J50lj9E=
 github.com/whyrusleeping/chunker v0.0.0-20181014151217-fe64bd25879f/go.mod h1:p9UJB6dDgdPgMJZs7UjUOdulKyRr9fqkS+6JKAInPy8=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -151,9 +151,9 @@ func (m *MockInterface) Shutdown() error {
 }
 
 // Shutdown indicates an expected call of Shutdown.
-func (mr *MockInterfaceMockRecorder) Shutdown(arg0 interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Shutdown() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockInterface)(nil).Shutdown), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Shutdown", reflect.TypeOf((*MockInterface)(nil).Shutdown))
 }
 
 // MockMultihashIterator is a mock of MultihashIterator interface.


### PR DESCRIPTION
Re-implement the engine tests that assert advertisement publish with
data transfer publisher works correctly with expected extra gossip data

Add various tests that assert returned error types.

Re-generate mock files.

Upgrade to the latest go-legs

Remove the old tests that poked inside the engine, and move all engine
tests to a separate `_test` package.