### PR TITLE
Rename `Callback` to a more specific name: `MultihashLister`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A list of features include:
       chunking functionality
     * Announcement of changes to the advertised content over GossipSub
       using [`go-legs`](https://github.com/filecoin-project/go-legs)
-    * `Callback` integration point for fully customizable look up of advertised multihashes.
+    * `MultihashLister` integration point for fully customizable look up of advertised multihashes.
     * Utilities to advertise multihashes directly [from CAR files](supplier/car_supplier.go)
       or [detached CARv2 index](index_mh_iter.go) files.
     * Index advertisement [`metadata`](metadata) schema for retrieval
@@ -128,9 +128,9 @@ Each advertisement contains:
 Within each advertisement there is an entries link that points to a list of chunked multihashes. It
 is the multihashes that
 
-To do this it requires a `Callback` to be registered. The `Callback` is then used to look up the
-list of multihashes associated to a content advertisement. For an example on how to startup a 
-provider engine, register a callback and advertise content, see:
+To do this it requires a `MultihashLister` to be registered. The `MultihashLister` is then used to
+look up the list of multihashes associated to a content advertisement. For an example on how to
+start up a provider engine, register a lister and advertise content, see:
 
 * [`engine/example_test.go`](engine/example_test.go)
 

--- a/cardatatransfer/doc.go
+++ b/cardatatransfer/doc.go
@@ -1,3 +1,3 @@
 // Package cardatatransfer privdes a datatransfer server that can be used to retrieve multihashes
-// supplied via engine.Engine and supplier.CarSupplier as the provider.Callback.
+// supplied via engine.Engine and supplier.CarSupplier as the provider.MultihashLister.
 package cardatatransfer

--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -133,7 +133,7 @@ func daemonCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	// Instantiate CAR supplier and register it as a callback onto the engine.
+	// Instantiate CAR supplier and register it as the multihash lister onto the engine.
 	cs := supplier.NewCarSupplier(eng, ds, car.ZeroLengthSectionAsEOF(carZeroLengthAsEOFFlagValue))
 
 	// Start serving CAR files for retrieval requests

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -129,7 +129,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 	require.NoError(t, err)
 
 	wantContextID := []byte("fish")
-	subject.RegisterCallback(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	subject.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 		if string(contextID) == string(wantContextID) {
 			return &sliceMhIterator{
 				mhs: mhs,
@@ -216,7 +216,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestEngine_NotifyPutWithoutCallbackIsError(t *testing.T) {
+func TestEngine_NotifyPutWithoutListerIsError(t *testing.T) {
 	ctx := contextWithTimeout(t)
 	subject, err := engine.New()
 	require.NoError(t, err)
@@ -225,7 +225,7 @@ func TestEngine_NotifyPutWithoutCallbackIsError(t *testing.T) {
 	defer subject.Shutdown()
 
 	gotCid, err := subject.NotifyPut(ctx, []byte("fish"), metadata.BitswapMetadata)
-	require.Error(t, err, provider.ErrNoCallback)
+	require.Error(t, err, provider.ErrNoMultihashLister)
 	require.Equal(t, cid.Undef, gotCid)
 }
 
@@ -243,7 +243,7 @@ func TestEngine_NotifyPutThenNotifyRemove(t *testing.T) {
 	defer subject.Shutdown()
 
 	wantContextID := []byte("fish")
-	subject.RegisterCallback(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	subject.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 		if string(contextID) == string(wantContextID) {
 			return &sliceMhIterator{
 				mhs: mhs,

--- a/engine/example_test.go
+++ b/engine/example_test.go
@@ -45,13 +45,13 @@ func Example_advertiseHelloWorld() {
 	fmt.Println("✓ Instantiated provider engine")
 	defer engine.Shutdown()
 
-	engine.RegisterCallback(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	engine.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 		if string(contextID) == sayHelloCtxID {
 			return &singleMhIterator{mh: mh}, nil
 		}
 		return nil, fmt.Errorf("no content is found for context ID: %v", contextID)
 	})
-	fmt.Printf("✓ Registered callback for context ID: %s\n", sayHelloCtxID)
+	fmt.Printf("✓ Registered lister for context ID: %s\n", sayHelloCtxID)
 
 	// Start the engine
 	if err = engine.Start(context.Background()); err != nil {
@@ -77,7 +77,7 @@ func Example_advertiseHelloWorld() {
 	//✓ Generated content multihash: QmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e
 	//✓ Instantiated new libp2p host with peer ID: Qm...
 	//✓ Instantiated provider engine
-	//✓ Registered callback for context ID: Say hello
+	//✓ Registered lister for context ID: Say hello
 	//✓ Provider engine started.
 	//✓ Published advertisement for content with CID: bag...
 }

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -55,10 +55,10 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 
 		// Not an advertisement, so this means we are receiving ingestion data.
 
-		// If no callback registered return error
-		if e.cb == nil {
-			log.Error("No callback has been registered in engine")
-			return nil, provider.ErrNoCallback
+		// If no lister registered return error
+		if e.mhLister == nil {
+			log.Error("No multihash lister has been registered in engine")
+			return nil, provider.ErrNoMultihashLister
 		}
 
 		log.Debugw("Checking cache for data", "cid", c)
@@ -82,7 +82,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			log.Infow("Entry for CID is not cached, generating chunks", "cid", c)
 			// If the link is not found, it means that the root link of the list has
 			// not been generated and we need to get the relationship between the cid
-			// received and the contextID so the callback knows how to
+			// received and the contextID so the lister knows how to
 			// regenerate the list of CIDs.
 			key, err := e.getCidKeyMap(ctx, c)
 			if err != nil {
@@ -95,7 +95,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// deletes all indexes for the contextID in the removal
 			// advertisement.  Only if the removal had no contextID would the
 			// indexer ask for entry chunks to remove.
-			mhIter, err := e.cb(ctx, key)
+			mhIter, err := e.mhLister(ctx, key)
 			if err != nil {
 				return nil, err
 			}
@@ -105,7 +105,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// datastore.
 			_, err = e.entriesChunker.Chunk(ctx, mhIter)
 			if err != nil {
-				log.Errorf("Error generating linked list from callback: %s", err)
+				log.Errorf("Error generating linked list from multihash lister: %s", err)
 				return nil, err
 			}
 		} else {

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -49,9 +49,9 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 	mhs, err := testutil.RandomCids(rng, 12)
 	require.NoError(t, err)
 
-	// Register callback with removal handle
+	// Register lister with removal handle
 	var removed bool
-	subject.RegisterCallback(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	subject.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 		strCtxID := string(contextID)
 		if strCtxID == string(ctxID) && !removed {
 			return getMhIterator(t, mhs), nil
@@ -74,7 +74,7 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 	// Clear cached entries to force re-generation of chunks on traversal
 	require.NoError(t, subject.Chunker().Clear(ctx))
 
-	// Signal to callback that context ID must no longer be found
+	// Signal to lister that context ID must no longer be found
 	removed = true
 
 	// Publish content removed advertisement
@@ -121,7 +121,7 @@ func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {
 	ad2Mhs, err := testutil.RandomCids(rng, ad2MhCount)
 	require.NoError(t, err)
 
-	subject.RegisterCallback(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	subject.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 		strCtxID := string(contextID)
 		if strCtxID == string(ad1CtxID) {
 			return getMhIterator(t, ad1Mhs), nil

--- a/errors.go
+++ b/errors.go
@@ -3,13 +3,13 @@ package provider
 import "errors"
 
 var (
-	// ErrNoCallback is thrown when no callback has been defined.
-	ErrNoCallback = errors.New("no callback is registered")
+	// ErrNoMultihashLister signals that no provider.MultihashLister is registered for lookup.
+	ErrNoMultihashLister = errors.New("no multihash lister is registered")
 
 	// ErrContextIDNotFound signals that no item is associated to the given context ID.
 	ErrContextIDNotFound = errors.New("context ID not found")
 
-	// ErrAlreadyAdvertised indicates that an advertisement for identical
-	// content was already published.
+	// ErrAlreadyAdvertised signals that an advertisement for identical content was already
+	// published.
 	ErrAlreadyAdvertised = errors.New("advertisement already published")
 )

--- a/interface.go
+++ b/interface.go
@@ -16,7 +16,7 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-// Interface represents an index provider that manages the advertisement of
+// Interface represents an index provider that manages the advertisement for
 // multihashes to indexer nodes.
 type Interface interface {
 	// PublishLocal appends adv to the locally stored advertisement chain and
@@ -33,20 +33,20 @@ type Interface interface {
 	// represents the ID of the advertisement appended to the chain.
 	Publish(context.Context, schema.Advertisement) (cid.Cid, error)
 
-	// RegisterCallback registers the callback used by the provider to look up
-	// a list of multihashes by context ID.  Only a single callback is
+	// RegisterMultihashLister registers the hook that is used by the provider to look up
+	// a list of multihashes by context ID. Only a single registration is
 	// supported; repeated calls to this function will replace the previous
-	// callback.
-	RegisterCallback(Callback)
+	// registration.
+	RegisterMultihashLister(MultihashLister)
 
 	// NotifyPut signals the provider that the list of multihashes looked up by
 	// the given contextID is available.  The given contextID is then used to
-	// look up the list of multihashes via Callback.  An advertisement is then
+	// look up the list of multihashes via MultihashLister.  An advertisement is then
 	// generated, appended to the chain of advertisements and published onto
 	// the gossip pubsub channel.
 	//
-	// A Callback must be registered prior to using this function.
-	// ErrNoCallback is returned if no such callback is registered.
+	// A MultihashLister must be registered prior to using this function.
+	// ErrNoMultihashLister is returned if no such lister is registered.
 	//
 	// The metadata is data that provides hints about how to retrieve data and
 	// is protocol dependant.  The metadata must at least specify a protocol
@@ -58,7 +58,7 @@ type Interface interface {
 	// This function returns the ID of the advertisement published.
 	NotifyPut(ctx context.Context, contextID []byte, metadata stiapi.Metadata) (cid.Cid, error)
 
-	// NotifyRemove sginals to the provider that the multihashes that
+	// NotifyRemove signals to the provider that the multihashes that
 	// corresponded to the given contextID are no longer available.  An advertisement
 	// is then generated, appended to the chain of advertisements and published
 	// onto the gossip pubsub channel.
@@ -76,7 +76,7 @@ type Interface interface {
 	GetLatestAdv(context.Context) (cid.Cid, schema.Advertisement, error)
 
 	// Shutdown shuts down this provider, and blocks until all resources
-	// occupied by it are discared.  After calling this function the provider
+	// occupied by it are discarded.  After calling this function the provider
 	// is no longer available for use.
 	Shutdown() error
 }
@@ -92,9 +92,9 @@ type MultihashIterator interface {
 	Next() (multihash.Multihash, error)
 }
 
-// Callback is used by provider to look up a list of multihashes associated to
-// a context ID.  The callback must be deterministic: it must produce the same
-// list of multihashes in the same order for the same context ID.
+// MultihashLister lists the multihashes that correspond to a given contextID.
+// The lister must be deterministic: it must produce the same list of multihashes in the same
+// order for the same context ID.
 //
 // See: Interface.NotifyPut, Interface.NotifyRemove, MultihashIterator.
-type Callback func(ctx context.Context, contextID []byte) (MultihashIterator, error)
+type MultihashLister func(ctx context.Context, contextID []byte) (MultihashIterator, error)

--- a/mock/interface.go
+++ b/mock/interface.go
@@ -130,16 +130,16 @@ func (mr *MockInterfaceMockRecorder) PublishLocal(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishLocal", reflect.TypeOf((*MockInterface)(nil).PublishLocal), arg0, arg1)
 }
 
-// RegisterCallback mocks base method.
-func (m *MockInterface) RegisterCallback(arg0 provider.Callback) {
+// RegisterMultihashLister mocks base method.
+func (m *MockInterface) RegisterMultihashLister(arg0 provider.MultihashLister) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterCallback", arg0)
+	m.ctrl.Call(m, "RegisterMultihashLister", arg0)
 }
 
-// RegisterCallback indicates an expected call of RegisterCallback.
-func (mr *MockInterfaceMockRecorder) RegisterCallback(arg0 interface{}) *gomock.Call {
+// RegisterMultihashLister indicates an expected call of RegisterMultihashLister.
+func (mr *MockInterfaceMockRecorder) RegisterMultihashLister(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterCallback", reflect.TypeOf((*MockInterface)(nil).RegisterCallback), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterMultihashLister", reflect.TypeOf((*MockInterface)(nil).RegisterMultihashLister), arg0)
 }
 
 // Shutdown mocks base method.

--- a/server/admin/http/importcar_handler_test.go
+++ b/server/admin/http/importcar_handler_test.go
@@ -41,7 +41,7 @@ func Test_importCarHandler(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -90,7 +90,7 @@ func Test_importCarHandlerFail(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -131,7 +131,7 @@ func Test_importCarAlreadyAdvertised(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 

--- a/server/admin/http/removecar_handler_test.go
+++ b/server/admin/http/removecar_handler_test.go
@@ -30,7 +30,7 @@ func Test_removeCarHandler(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -66,7 +66,7 @@ func Test_removeCarHandlerFail(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -96,7 +96,7 @@ func Test_removeCarHandler_NonExistingCarIsNotFound(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -114,7 +114,7 @@ func Test_removeCarHandler_UnspecifiedKeyIsBadRequest(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 
@@ -132,7 +132,7 @@ func Test_removeCarHandler_InvalidJsonIsBadRequest(t *testing.T) {
 
 	mc := gomock.NewController(t)
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	ds := dssync.MutexWrap(datastore.NewMapDatastore())
 	cs := supplier.NewCarSupplier(mockEng, ds)
 

--- a/supplier/car_supplier.go
+++ b/supplier/car_supplier.go
@@ -28,9 +28,9 @@ var ErrNotFound = errors.New("no CID iterator found for given key")
 
 var log = logging.Logger("provider/carsupplier")
 
-// CarSupplier supplies multihashes to an implementation of Provider.Interface via provider.Callback.
-// It allows the users to advertise addition and removal of multihashes within CAR files by simply
-// calling CarSupplier.Put and CarSupplier.Remove.
+// CarSupplier supplies multihashes to an implementation of Provider.Interface via
+// provider.MultihashLister. It allows the users to advertise addition and removal of multihashes
+// within CAR files by simply calling CarSupplier.Put and CarSupplier.Remove.
 //
 // CarSupplier accepts both CARv1 and CARv2, and will automatically generate an index if one is not
 // present or the index codec and characteristics are not sufficient for provider.Interface purposes.
@@ -42,7 +42,7 @@ type CarSupplier struct {
 	opts []car.ReadOption
 }
 
-// NewCarSupplier instantiates a new CarSupplier and registers it as the provider.Callback of the
+// NewCarSupplier instantiates a new CarSupplier and registers it as the provider.MultihashLister of the
 // given provider.Interface.
 func NewCarSupplier(eng provider.Interface, ds datastore.Datastore, opts ...car.ReadOption) *CarSupplier {
 	cs := &CarSupplier{
@@ -50,7 +50,7 @@ func NewCarSupplier(eng provider.Interface, ds datastore.Datastore, opts ...car.
 		ds:   ds,
 		opts: opts,
 	}
-	eng.RegisterCallback(cs.Callback)
+	eng.RegisterMultihashLister(cs.ListMultihashes)
 	return cs
 }
 
@@ -101,9 +101,9 @@ func (cs *CarSupplier) Remove(ctx context.Context, contextID []byte) (cid.Cid, e
 	return cs.eng.NotifyRemove(ctx, contextID)
 }
 
-// Callback supplies an iterator over CIDs of the CAR file that corresponds to
+// ListMultihashes supplies an iterator over CIDs of the CAR file that corresponds to
 // the given key.  An error is returned if no CAR file is found for the key.
-func (cs *CarSupplier) Callback(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
+func (cs *CarSupplier) ListMultihashes(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {
 	idx, err := cs.lookupIterableIndex(ctx, contextID)
 	if err != nil {
 		return nil, err

--- a/supplier/car_supplier_test.go
+++ b/supplier/car_supplier_test.go
@@ -59,7 +59,7 @@ func TestPutCarReturnsExpectedIterator(t *testing.T) {
 			defer cancel()
 			mockEng := mock_provider.NewMockInterface(mc)
 			ds := datastore.NewMapDatastore()
-			mockEng.EXPECT().RegisterCallback(gomock.Any())
+			mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 			subject := NewCarSupplier(mockEng, ds, tt.opts...)
 			t.Cleanup(func() { require.NoError(t, subject.Close()) })
 
@@ -102,7 +102,7 @@ func TestPutCarReturnsExpectedIterator(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, wantCid, gotCid)
 
-			gotIterator, err := subject.Callback(ctx, gotContextID)
+			gotIterator, err := subject.ListMultihashes(ctx, gotContextID)
 			require.NoError(t, err)
 
 			gotMultihashes := 0
@@ -139,7 +139,7 @@ func TestRemovedPathIsNoLongerSupplied(t *testing.T) {
 	ds := datastore.NewMapDatastore()
 
 	mockEng := mock_provider.NewMockInterface(mc)
-	mockEng.EXPECT().RegisterCallback(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
 	subject := NewCarSupplier(mockEng, ds)
 	t.Cleanup(func() { require.NoError(t, subject.Close()) })
 

--- a/supplier/doc.go
+++ b/supplier/doc.go
@@ -1,5 +1,5 @@
 // Package supplier provides mechanisms to supply mulithashes to an index-provider engine via
-// provider.Callback.
+// provider.MultihashLister
 // The only implemented mechanism is CarSupplier, that in conjunction with an engine allows a user
 // to advertise multihashes by simply providing CAR files.
 package supplier


### PR DESCRIPTION
Use a more specific term to descibe the hook used by the index provider
engine to list multihashes associated to a context ID:
`MultihashLister`, and update docs as needed.