### PR TITLE
Replace IPLD accumulate with IPLD schema file

### DIFF
--- a/metadata/graphsync_filecoinv1.ipldsch
+++ b/metadata/graphsync_filecoinv1.ipldsch
@@ -1,0 +1,5 @@
+type GraphsyncFilecoinV1 struct {
+	PieceCID Link
+	VerifiedDeal Bool
+	FastRetrieval Bool
+}


### PR DESCRIPTION
Add a dedicated IPLD schema type for GraphSyncFilecoinV1 metadata
protocol to replace the schema created using IPLD `Accumulate`.

Fixes: #82