### PR TITLE
Remove dependency to `go-ipfs-blocksutil` used only for testing

### DIFF
--- a/cardatatransfer/cardatatransfer_test.go
+++ b/cardatatransfer/cardatatransfer_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 )
 
 func TestCarDataTransfer(t *testing.T) {
+	rng := rand.New(rand.NewSource(1413))
 	contextID1 := []byte("cheese")
 	rdOnlyBS1 := testutil.OpenSampleCar(t, "sample-v1-2.car")
 
@@ -51,7 +53,7 @@ func TestCarDataTransfer(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, roots2, 1)
 
-	missingCid := testutil.GenerateCids(1)[0]
+	missingCid := testutil.RandomCids(t, rng, 1)[0]
 	missingContextID := []byte("notFound")
 
 	supplier := &fakeSupplier{blockstores: make(map[string]supplier.ClosableBlockstore)}
@@ -77,7 +79,7 @@ func TestCarDataTransfer(t *testing.T) {
 	pieceCID2 := pieceCIDFromContextID(t, contextID2)
 	missingPieceCID := pieceCIDFromContextID(t, missingContextID)
 
-	incorrectPieceCid := testutil.GenerateCids(1)[0]
+	incorrectPieceCid := testutil.RandomCids(t, rng, 1)[0]
 
 	testCases := map[string]struct {
 		voucher                  datatransfer.Voucher

--- a/engine/chunker/cached_chunker_test.go
+++ b/engine/chunker/cached_chunker_test.go
@@ -33,8 +33,7 @@ func TestCachedEntriesChunker_OverlappingLinkCounter(t *testing.T) {
 	defer subject.Close()
 
 	// Cache a link with 2 full chunks
-	c1Cids, err := testutil.RandomCids(rng, 20)
-	require.NoError(t, err)
+	c1Cids := testutil.RandomCids(t, rng, 20)
 	c1Lnk, err := subject.Chunk(ctx, getMhIterator(t, c1Cids))
 	require.NoError(t, err)
 	c1Chain := listEntriesChain(t, subject, c1Lnk)
@@ -43,8 +42,7 @@ func TestCachedEntriesChunker_OverlappingLinkCounter(t *testing.T) {
 
 	for i := 1; i < capacity*2; i++ {
 		// Generate a chunk worth of CIDs
-		newCids, err := testutil.RandomCids(rng, 10*rng.Intn(4)+1)
-		require.NoError(t, err)
+		newCids := testutil.RandomCids(t, rng, 10*rng.Intn(4)+1)
 		// Append to the previously generated CIDs
 		newCids = append(c1Cids, newCids...)
 		wantChainLen := math.Ceil(float64(len(newCids)) / float64(chunkSize))
@@ -171,8 +169,7 @@ func TestCachedEntriesChunker_PreviouslyCachedChunksAreRestored(t *testing.T) {
 	requireChunkIsCached(t, subject, c1Chain...)
 
 	// Chunk another iterators with overlapping section.
-	c2Cids, err := testutil.RandomCids(rng, 12)
-	require.NoError(t, err)
+	c2Cids := testutil.RandomCids(t, rng, 12)
 	c2Lnk, err := subject.Chunk(ctx, getMhIterator(t, c2Cids))
 	require.NoError(t, err)
 
@@ -182,7 +179,7 @@ func TestCachedEntriesChunker_PreviouslyCachedChunksAreRestored(t *testing.T) {
 	requireChunkIsCached(t, subject, c2Chain...)
 
 	// Chunk and cache another multihash iterators with overlapping section.
-	c3Cids, err := testutil.RandomCids(rng, 13)
+	c3Cids := testutil.RandomCids(t, rng, 13)
 	require.NoError(t, err)
 	c3Cids = append(c2Cids, c3Cids...)
 	c3Lnk, err := subject.Chunk(ctx, getMhIterator(t, c3Cids))
@@ -223,7 +220,7 @@ func TestCachedEntriesChunker_OverlappingDagIsNotEvicted(t *testing.T) {
 	//  2. Its entries match the original CIDs
 	//  3. The length of chain is 1, i.e. the chunk has no next since chunkSize = 10
 	//  4. The cache length is 1.
-	c1Cids, err := testutil.RandomCids(rng, 10)
+	c1Cids := testutil.RandomCids(t, rng, 10)
 	require.NoError(t, err)
 	c1Lnk, err := subject.Chunk(ctx, getMhIterator(t, c1Cids))
 	require.NoError(t, err)
@@ -241,7 +238,7 @@ func TestCachedEntriesChunker_OverlappingDagIsNotEvicted(t *testing.T) {
 	//  3. The first entry in chain has all the newly generated CIDs
 	//  4. The second entry in chain is identical to c1.
 	//  5. The length of cache is still 1.
-	extraCids, err := testutil.RandomCids(rng, 10)
+	extraCids := testutil.RandomCids(t, rng, 10)
 	require.NoError(t, err)
 	c2Cids := append(c1Cids, extraCids...)
 	c2Lnk, err := subject.Chunk(ctx, getMhIterator(t, c2Cids))
@@ -318,8 +315,7 @@ func requireDecodeAsEntryChunk(t *testing.T, l ipld.Link, value []byte) *schema.
 }
 
 func getRandomMhIterator(t *testing.T, rng *rand.Rand, mhCount int) provider.MultihashIterator {
-	cids, err := testutil.RandomCids(rng, mhCount)
-	require.NoError(t, err)
+	cids := testutil.RandomCids(t, rng, mhCount)
 	return getMhIterator(t, cids)
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -43,8 +43,7 @@ func TestEngine_PublishLocal(t *testing.T) {
 	ctx := contextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
-	mhs, err := testutil.RandomMultihashes(rng, 42)
-	require.NoError(t, err)
+	mhs := testutil.RandomMultihashes(t, rng, 42)
 
 	subject, err := engine.New()
 	require.NoError(t, err)
@@ -84,8 +83,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 	ctx := contextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
-	mhs, err := testutil.RandomMultihashes(rng, 42)
-	require.NoError(t, err)
+	mhs := testutil.RandomMultihashes(t, rng, 42)
 
 	wantExtraGossipData := []byte("🐠")
 	// Use test name as gossip topic name for uniqueness per test.
@@ -236,8 +234,7 @@ func TestEngine_NotifyPutThenNotifyRemove(t *testing.T) {
 	ctx := contextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
-	mhs, err := testutil.RandomMultihashes(rng, 42)
-	require.NoError(t, err)
+	mhs := testutil.RandomMultihashes(t, rng, 42)
 
 	subject, err := engine.New()
 	require.NoError(t, err)

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -48,7 +48,7 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 	defer subject.Shutdown()
 
 	ctxID := []byte("added then removed content")
-	mhs, err := testutil.RandomCids(rng, 12)
+	mhs := testutil.RandomCids(t, rng, 12)
 	require.NoError(t, err)
 
 	// Register lister with removal handle
@@ -112,13 +112,13 @@ func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {
 	ad1CtxID := []byte("first")
 	ad1MhCount := 12
 	wantAd1EntriesChainLen := ad1MhCount / chunkSize
-	ad1Mhs, err := testutil.RandomCids(rng, ad1MhCount)
+	ad1Mhs := testutil.RandomCids(t, rng, ad1MhCount)
 	require.NoError(t, err)
 
 	ad2CtxID := []byte("second")
 	ad2MhCount := 10
 	wantAd2ChunkLen := ad2MhCount / chunkSize
-	ad2Mhs, err := testutil.RandomCids(rng, ad2MhCount)
+	ad2Mhs := testutil.RandomCids(t, rng, ad2MhCount)
 	require.NoError(t, err)
 
 	subject.RegisterMultihashLister(func(ctx context.Context, contextID []byte) (provider.MultihashIterator, error) {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,6 @@ require (
 	github.com/ipfs/go-datastore v0.5.1
 	github.com/ipfs/go-graphsync v0.12.0
 	github.com/ipfs/go-ipfs-blockstore v1.1.2
-	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log/v2 v2.5.0
 	github.com/ipld/go-car/v2 v2.1.1
 	github.com/ipld/go-codec-dagpb v1.3.0

--- a/metadata/graphsync_filecoinv1_test.go
+++ b/metadata/graphsync_filecoinv1_test.go
@@ -1,6 +1,7 @@
 package metadata_test
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/filecoin-project/index-provider/metadata"
@@ -11,7 +12,8 @@ import (
 )
 
 func TestRoundTripDataTransferFilecoin(t *testing.T) {
-	cids := testutil.GenerateCids(4)
+	rng := rand.New(rand.NewSource(1413))
+	cids := testutil.RandomCids(t, rng, 4)
 	filecoinV1Datas := []*metadata.GraphsyncFilecoinV1{
 		{
 			PieceCID:      cids[0],

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestMetadata(t *testing.T) {
-	cids := testutil.GenerateCids(4)
+	rng := rand.New(rand.NewSource(1413))
+	cids := testutil.RandomCids(t, rng, 4)
 	tests := []struct {
 		name            string
 		givenTransports []metadata.Protocol

--- a/server/admin/http/importcar_handler_test.go
+++ b/server/admin/http/importcar_handler_test.go
@@ -57,7 +57,7 @@ func Test_importCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handle)
-	randCids, err := testutil.RandomCids(rng, 1)
+	randCids := testutil.RandomCids(t, rng, 1)
 	require.NoError(t, err)
 	wantCid := randCids[0]
 

--- a/server/admin/http/removecar_handler_test.go
+++ b/server/admin/http/removecar_handler_test.go
@@ -39,7 +39,7 @@ func Test_removeCarHandler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	handler := http.HandlerFunc(subject.handle)
-	wantCid := requireRandomCid(t, rng)
+	wantCid := testutil.RandomCids(t, rng, 1)[0]
 	requireMockPut(t, mockEng, wantKey, cs, rng)
 
 	mockEng.
@@ -163,7 +163,7 @@ func requireRemoveCarHttpRequest(t *testing.T, body io.Reader) *http.Request {
 func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []byte, cs *supplier.CarSupplier, rng *rand.Rand) {
 	wantTp, err := cardatatransfer.TransportFromContextID(key)
 	require.NoError(t, err)
-	wantCid := requireRandomCid(t, rng)
+	wantCid := testutil.RandomCids(t, rng, 1)[0]
 	wantMetadata := metadata.New(wantTp)
 	mockEng.
 		EXPECT().
@@ -171,10 +171,4 @@ func requireMockPut(t *testing.T, mockEng *mock_provider.MockInterface, key []by
 		Return(wantCid, nil)
 	_, err = cs.Put(context.Background(), key, "/fish/in/da/sea", wantMetadata)
 	require.NoError(t, err)
-}
-
-func requireRandomCid(t *testing.T, rng *rand.Rand) cid.Cid {
-	randCids, err := testutil.RandomCids(rng, 1)
-	require.NoError(t, err)
-	return randCids[0]
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ipfs/go-datastore"
 	gsimpl "github.com/ipfs/go-graphsync/impl"
 	gsnet "github.com/ipfs/go-graphsync/network"
-	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	carv2 "github.com/ipld/go-car/v2"
 	"github.com/ipld/go-car/v2/blockstore"
 	"github.com/ipld/go-ipld-prime"
@@ -26,19 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var blockGenerator = blocksutil.NewBlockGenerator()
-
-// GenerateCids produces n content identifiers.
-func GenerateCids(n int) []cid.Cid {
-	cids := make([]cid.Cid, n)
-	for i := 0; i < n; i++ {
-		c := blockGenerator.Next().Cid()
-		cids[i] = c
-	}
-	return cids
-}
-
-func RandomCids(rng *rand.Rand, n int) ([]cid.Cid, error) {
+func RandomCids(t *testing.T, rng *rand.Rand, n int) []cid.Cid {
 	prefix := schema.Linkproto.Prefix
 
 	cids := make([]cid.Cid, n)
@@ -46,15 +33,13 @@ func RandomCids(rng *rand.Rand, n int) ([]cid.Cid, error) {
 		b := make([]byte, 10*n)
 		rng.Read(b)
 		c, err := prefix.Sum(b)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(t, err)
 		cids[i] = c
 	}
-	return cids, nil
+	return cids
 }
 
-func RandomMultihashes(rng *rand.Rand, n int) ([]multihash.Multihash, error) {
+func RandomMultihashes(t *testing.T, rng *rand.Rand, n int) []multihash.Multihash {
 	prefix := schema.Linkproto.Prefix
 
 	mhashes := make([]multihash.Multihash, n)
@@ -62,12 +47,10 @@ func RandomMultihashes(rng *rand.Rand, n int) ([]multihash.Multihash, error) {
 		b := make([]byte, 10*n)
 		rng.Read(b)
 		c, err := prefix.Sum(b)
-		if err != nil {
-			return nil, err
-		}
+		require.NoError(t, err)
 		mhashes[i] = c.Hash()
 	}
-	return mhashes, nil
+	return mhashes
 }
 
 // ThisDir gets the current directory of the source file its called in


### PR DESCRIPTION
Remove duplicate logic for random CID generation, which also results in
removing dependency to `go-ipfs-blocksutil` and more reproducible tests.