### PR TITLE
New announce command to announce latest advertisement

### DIFF
--- a/cmd/provider/announce.go
+++ b/cmd/provider/announce.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/urfave/cli/v2"
+)
+
+var AnnounceCmd = &cli.Command{
+	Name:   "announce",
+	Usage:  "Publish an announcement message for the latest advertisement",
+	Flags:  announceFlags,
+	Action: announceCommand,
+}
+
+func announceCommand(cctx *cli.Context) error {
+	req, err := http.NewRequestWithContext(cctx.Context, http.MethodPost, adminAPIFlagValue+"/admin/announce", nil)
+	if err != nil {
+		return err
+	}
+
+	cl := &http.Client{}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	// Handle failed requests
+	if resp.StatusCode != http.StatusOK {
+		return errFromHttpResp(resp)
+	}
+
+	_, err = cctx.App.Writer.Write([]byte("Announced latest advertisement\n"))
+	return err
+}

--- a/cmd/provider/flags.go
+++ b/cmd/provider/flags.go
@@ -4,6 +4,10 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var announceFlags = []cli.Flag{
+	adminAPIFlag,
+}
+
 var daemonFlags = []cli.Flag{
 	carZeroLengthAsEOFFlag,
 	&cli.StringFlag{

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -41,16 +41,17 @@ func run() int {
 		Usage:   "Indexer Reference Provider Implementation",
 		Version: version,
 		Commands: []*cli.Command{
+			AnnounceCmd,
+			ConnectCmd,
 			DaemonCmd,
 			FindCmd,
+			ImportCmd,
 			IndexCmd,
 			InitCmd,
-			ConnectCmd,
-			ImportCmd,
+			ListCmd,
 			RegisterCmd,
 			RemoveCmd,
 			VerifyIngestCmd,
-			ListCmd,
 		},
 	}
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -114,10 +114,15 @@ func (e *Engine) Start(ctx context.Context) error {
 		return err
 	}
 
-	err = e.PublishLatest(ctx)
+	// Initialize publisher with latest advertisement CID.
+	adCid, err := e.getLatestAdCid(ctx)
 	if err != nil {
-		log.Errorw("Could not republish latest advertisement", "err", err)
-		return err
+		return fmt.Errorf("could not get latest advertisement cid: %w", err)
+	}
+	if adCid != cid.Undef {
+		if err = e.publisher.SetRoot(ctx, adCid); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -211,8 +216,7 @@ func (e *Engine) PublishLatest(ctx context.Context) error {
 
 	adCid, err := e.getLatestAdCid(ctx)
 	if err != nil {
-		log.Errorw("Failed to get the latest advertisement CID", "err", err)
-		return fmt.Errorf("failed to get latest advertisement cid from blockstore: %w", err)
+		return fmt.Errorf("failed to get latest advertisement cid: %w", err)
 	}
 
 	if adCid == cid.Undef {

--- a/server/admin/http/announce_handler.go
+++ b/server/admin/http/announce_handler.go
@@ -1,0 +1,16 @@
+package adminserver
+
+import (
+	"net/http"
+)
+
+func (s *Server) announceHandler(w http.ResponseWriter, r *http.Request) {
+	err := s.e.PublishLatest(r.Context())
+	if err != nil {
+		log.Errorw("Could not republish latest advertisement", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -22,7 +22,6 @@ type Server struct {
 }
 
 func New(h host.Host, e *engine.Engine, cs *supplier.CarSupplier, o ...Option) (*Server, error) {
-
 	opts, err := newOptions(o...)
 	if err != nil {
 		return nil, err
@@ -42,6 +41,9 @@ func New(h host.Host, e *engine.Engine, cs *supplier.CarSupplier, o ...Option) (
 	s := &Server{server, l, h, e}
 
 	// Set protocol handlers
+	r.HandleFunc("/admin/announce", s.announceHandler).
+		Methods(http.MethodPost)
+
 	r.HandleFunc("/admin/connect", s.connectHandler).
 		Methods(http.MethodPost).
 		Headers("Content-Type", "application/json")


### PR DESCRIPTION
The `announce` command publishes an announce for the latest advertisement.  This is useful to get indexers to sync without having to publish a new advertisement.

Additional change: On daemon startup, initialize the daemon with the latest ad CID but do not publish it.  Publishing the ad CID is not useful since the daemon will not yet have bootstrapped to any peers.  Having the `announce` command is a better as it allows optional publishing once the daemon is ready.