### PR TITLE
Bump version to `0.7.0` in preparation for release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.6.1"
+  "version": "v0.7.0"
 }


### PR DESCRIPTION


Bump version to 0.7.0 in prep for release. Rationale for larger bump:
 - go mod version upgrade.