### PR TITLE
Do not assume build system has bash shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-./provider
+provider
 dist/

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,7 @@
-.SHELLFLAGS := -eu -o pipefail -c
 MAKEFLAGS += --warn-undefined-variables
 MAKEFLAGS += --no-builtin-rules
 
-TAG ?= $(shell git fetch --tags && git describe --tags --abbrev=0 | sed 's/v//')
+TAG ?= $(git describe --tags --abbrev=0 | sed 's/v//')
 COMMIT ?= $(shell git rev-parse --short HEAD)
 CLEAN ?= $(shell git diff --quiet --exit-code || echo '-SNAPSHOT')
 VERSION = $(TAG)$(CLEAN)-$(COMMIT)


### PR DESCRIPTION
- The build system may not have bash shell installed, so do not use bash-specific shell flags.  Instead only assume standard bourne shell capabilities.
- Do not do `git fetch --tags` since it is usually not necessary and requires github access or explicitly setting `TAG`.
- Fix .gitignore to correctly ignore provider executable.

Fixes #223