### PR TITLE
feat: advertisement http server module

### DIFF
--- a/server/admin/http/car_handler.go
+++ b/server/admin/http/car_handler.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/filecoin-project/index-provider"
+	"github.com/filecoin-project/index-provider/server/utils"
+
+	provider "github.com/filecoin-project/index-provider"
 	"github.com/filecoin-project/index-provider/metadata"
 	"github.com/filecoin-project/index-provider/supplier"
 	"github.com/ipfs/go-cid"
@@ -62,7 +64,10 @@ func (h *carHandler) handleImport(w http.ResponseWriter, r *http.Request) {
 
 	// Respond with successful import results.
 	resp := &ImportCarRes{req.Key, advID}
-	respond(w, http.StatusOK, resp)
+	if err := utils.Respond(w, http.StatusOK, resp); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
 }
 
 func (h *carHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
@@ -105,7 +110,10 @@ func (h *carHandler) handleRemove(w http.ResponseWriter, r *http.Request) {
 
 	// Respond with successful remove result.
 	resp := &RemoveCarRes{AdvId: advID}
-	respond(w, http.StatusOK, resp)
+	if err := utils.Respond(w, http.StatusOK, resp); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
 }
 
 func (h *carHandler) handleList(w http.ResponseWriter, _ *http.Request) {
@@ -119,5 +127,8 @@ func (h *carHandler) handleList(w http.ResponseWriter, _ *http.Request) {
 	resp := &ListCarRes{
 		Paths: paths,
 	}
-	respond(w, http.StatusOK, resp)
+	if err := utils.Respond(w, http.StatusOK, resp); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
 }

--- a/server/admin/http/connect_handler.go
+++ b/server/admin/http/connect_handler.go
@@ -2,6 +2,7 @@ package adminserver
 
 import (
 	"fmt"
+	"github.com/filecoin-project/index-provider/server/utils"
 	"net/http"
 
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -46,5 +47,8 @@ func (s *Server) connectHandler(w http.ResponseWriter, r *http.Request) {
 	// Respond success case.
 	log.Infow("Connected to peer successfully", "addrInfo", addrInfo)
 	var resp ConnectRes
-	respond(w, http.StatusOK, &resp)
+	if err := utils.Respond(w, http.StatusOK, &resp); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
 }

--- a/server/admin/http/io.go
+++ b/server/admin/http/io.go
@@ -1,10 +1,9 @@
 package adminserver
 
 import (
-	"encoding/json"
 	"io"
-	"io/ioutil"
-	"net/http"
+
+	"github.com/filecoin-project/index-provider/server/utils"
 )
 
 var (
@@ -24,83 +23,57 @@ var (
 )
 
 func (er *ImportCarReq) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *ImportCarReq) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *ImportCarRes) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *ImportCarRes) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *RemoveCarReq) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *RemoveCarReq) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *RemoveCarRes) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *RemoveCarRes) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *ListCarRes) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *ListCarRes) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *ConnectReq) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *ConnectReq) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
+	return utils.UnmarshalAsJson(r, er)
 }
 
 func (er *ConnectRes) WriteTo(w io.Writer) (int64, error) {
-	return marshalToJson(w, er)
+	return utils.MarshalToJson(w, er)
 }
 
 func (er *ConnectRes) ReadFrom(r io.Reader) (int64, error) {
-	return unmarshalAsJson(r, er)
-}
-
-func respond(w http.ResponseWriter, statusCode int, body io.WriterTo) {
-	w.WriteHeader(statusCode)
-	// Attempt to serialize body as JSON
-	if _, err := body.WriteTo(w); err != nil {
-		log.Errorw("faild to write response ", "err", err)
-		return
-	}
-}
-
-func unmarshalAsJson(r io.Reader, dst interface{}) (int64, error) {
-	body, err := ioutil.ReadAll(r)
-	if err != nil {
-		return 0, err
-	}
-	return int64(len(body)), json.Unmarshal(body, dst)
-}
-
-func marshalToJson(w io.Writer, src interface{}) (int64, error) {
-	body, err := json.Marshal(src)
-	if err != nil {
-		return 0, err
-	}
-	written, err := w.Write(body)
-	return int64(written), err
+	return utils.UnmarshalAsJson(r, er)
 }

--- a/server/http_adv/client.go
+++ b/server/http_adv/client.go
@@ -1,0 +1,60 @@
+package http_adv
+
+import (
+	"bytes"
+	"context"
+	"github.com/filecoin-project/index-provider/server/utils"
+	"net/http"
+
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/ipfs/go-cid"
+)
+
+type Client struct {
+	url, token         string
+	mhitUrl, mhitToken string
+}
+
+func NewHttpAdvClient(url, token, mhitUrl, mhitToken string) (*Client, error) {
+	return &Client{url: url, token: token, mhitUrl: mhitUrl, mhitToken: mhitToken}, nil
+}
+
+func (c *Client) AnnounceAdv(ctx context.Context, ctxID []byte, reqID string, total uint64,
+	md metadata.Metadata, isDel bool) (cid.Cid, error) {
+	var req = &AnnounceAdvReq{
+		ReqID:     reqID,
+		Token:     c.mhitToken,
+		Url:       c.mhitUrl,
+		ContextID: ctxID,
+		Total:     total,
+		MetaData:  md,
+		IsDel:     isDel,
+	}
+
+	body := bytes.NewBuffer(nil)
+	if _, err := req.WriteTo(body); err != nil {
+		return cid.Undef, err
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url+announceAdvPath, body)
+	if err != nil {
+		return cid.Undef, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", c.token)
+	resp, err := (&http.Client{}).Do(httpReq)
+	if err != nil {
+		return cid.Undef, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return cid.Undef, utils.HttpStatusCodeErr(resp)
+	}
+
+	var advRes = &AnnounceAdvRes{}
+	if _, err := advRes.ReadFrom(resp.Body); err != nil {
+		return cid.Undef, err
+	}
+
+	return advRes.AdvId, nil
+}

--- a/server/http_adv/http_adv_test.go
+++ b/server/http_adv/http_adv_test.go
@@ -1,0 +1,112 @@
+package http_adv
+
+import (
+	"context"
+	"fmt"
+	"github.com/filecoin-project/index-provider/engine"
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/index-provider/server/http_mh_iter"
+	"github.com/filecoin-project/index-provider/server/utils"
+	"github.com/filecoin-project/index-provider/testutil"
+	"github.com/ipfs/go-cid"
+	"github.com/stretchr/testify/require"
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	ReqID            = "ReqID"
+	AdvToken         = "AdvToken"
+	MhToken          = "MhToken"
+	ContextID        = "ContextID"
+	AdvSvrListenAddr = "0.0.0.0:3106"
+	MhSvrListenAddr  = "0.0.0.0:3105"
+)
+
+func newMultihashIterSvr(t *testing.T) *http_mh_iter.Server {
+	svr, err := http_mh_iter.NewServer(
+		http_mh_iter.WithTokenVerify(func(reqID string, token string) error {
+			if reqID == ReqID && token == MhToken {
+				return nil
+			}
+			return fmt.Errorf("unauthurized")
+		}),
+		http_mh_iter.WithListenAddr(MhSvrListenAddr),
+	)
+
+	require.NoError(t, err)
+	return svr
+}
+
+func newAdvSvr(t *testing.T) *Server {
+	e, err := engine.New(engine.WithPublisherKind(engine.NoPublisher))
+	require.NoError(t, err)
+	require.NoError(t, e.Start(context.TODO()))
+
+	advSvr, err := NewServer(e, WithListenAddr(AdvSvrListenAddr),
+		WithTokenVerify(func(token string) error {
+			if token != AdvToken {
+				return utils.ErrUnauthorized
+			}
+			return nil
+		}),
+	)
+
+	e.RegisterMultihashLister(advSvr.ListMultihashes)
+
+	require.NoError(t, err)
+	return advSvr
+}
+
+func TestHttpAdv(t *testing.T) {
+	mhSvr := newMultihashIterSvr(t)
+	advSvr := newAdvSvr(t)
+
+	mhsCount := 1020
+	mhs := testutil.RandomMultihashes(t, rand.New(rand.NewSource(334455)), mhsCount)
+	mhSvr.AddMultiHashes([]byte(ContextID), mhs)
+
+	svrErrCh := make(chan error, 2)
+
+	go func() {
+		svrErrCh <- advSvr.Start()
+	}()
+	go func() {
+		svrErrCh <- mhSvr.Start()
+	}()
+
+	<-time.After(time.Millisecond * 100)
+
+	ctx := context.TODO()
+
+	advClient, err := NewHttpAdvClient(
+		"http://"+AdvSvrListenAddr, AdvToken,
+		"http://"+MhSvrListenAddr, MhToken)
+
+	require.NoError(t, err)
+
+	t.Run("TestAnnounceAdvertisementOk", func(t *testing.T) {
+		advCid, err := advClient.AnnounceAdv(ctx, []byte(ContextID), ReqID, uint64(mhsCount), metadata.Metadata{}, false)
+		require.NoError(t, err)
+		require.NotEqual(t, cid.Undef, advCid)
+		t.Logf("announce advertisement successfully, cid:%s", advCid.String())
+	})
+
+	t.Run("TestAnnounceAdvCtxNotFound", func(t *testing.T) {
+		_, err := advClient.AnnounceAdv(ctx, []byte("ContextIDNotFound"), ReqID, uint64(mhsCount), metadata.Metadata{}, false)
+		require.Equal(t, strings.Contains(err.Error(), "not found"), true)
+	})
+
+	svrErrCh <- nil
+
+	require.NoError(t, advSvr.Shutdown(ctx))
+	require.NoError(t, mhSvr.Shutdown(ctx))
+
+	select {
+	case e := <-svrErrCh:
+		require.NoError(t, e)
+	}
+
+}

--- a/server/http_adv/http_adv_test.go
+++ b/server/http_adv/http_adv_test.go
@@ -104,9 +104,5 @@ func TestHttpAdv(t *testing.T) {
 	require.NoError(t, advSvr.Shutdown(ctx))
 	require.NoError(t, mhSvr.Shutdown(ctx))
 
-	select {
-	case e := <-svrErrCh:
-		require.NoError(t, e)
-	}
-
+	require.NoError(t, <-svrErrCh)
 }

--- a/server/http_adv/models.go
+++ b/server/http_adv/models.go
@@ -1,0 +1,53 @@
+package http_adv
+
+import (
+	"io"
+
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/index-provider/server/utils"
+	"github.com/ipfs/go-cid"
+)
+
+var (
+	_ io.ReaderFrom = (*AnnounceAdvReq)(nil)
+	_ io.ReaderFrom = (*AnnounceAdvRes)(nil)
+	_ io.WriterTo   = (*AnnounceAdvReq)(nil)
+	_ io.WriterTo   = (*AnnounceAdvRes)(nil)
+)
+
+type (
+	// AnnounceAdvReq represents a request for publishing a raw advertisement.
+	AnnounceAdvReq struct {
+		ReqID string // the index multihash server may use to verify, based on advertisement request
+		Token string // the index multihash server used to verify request
+
+		Url       string // url to request multihashes
+		ContextID []byte // advertisement context id
+		Total     uint64 // total count of multihashes in the advertisement
+
+		MetaData metadata.Metadata
+
+		IsDel bool
+	}
+
+	// AnnounceAdvRes  represents the response to an AnnounceAdvReq.
+	AnnounceAdvRes struct {
+		AdvId cid.Cid `json:"adv_id"`
+	}
+)
+
+func (a *AnnounceAdvRes) WriteTo(w io.Writer) (n int64, err error) {
+	return utils.MarshalToJson(w, a)
+}
+
+func (a *AnnounceAdvReq) WriteTo(w io.Writer) (n int64, err error) {
+	return utils.MarshalToJson(w, a)
+}
+
+func (a *AnnounceAdvRes) ReadFrom(r io.Reader) (n int64, err error) {
+	return utils.UnmarshalAsJson(r, a)
+}
+
+func (a *AnnounceAdvReq) ReadFrom(r io.Reader) (n int64, err error) {
+	return utils.UnmarshalAsJson(r, a)
+}

--- a/server/http_adv/options.go
+++ b/server/http_adv/options.go
@@ -1,0 +1,76 @@
+package http_adv
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/filecoin-project/index-provider/server/utils"
+)
+
+type (
+	FnVerifyToken func(string) error
+
+	Option func(*options) error
+
+	options struct {
+		utils.Options
+		httpMultiHashPageSize uint64
+		VerifyToken           FnVerifyToken
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	opts := &options{
+		Options: utils.Options{
+			ListenAddr:   "0.0.0.0:3106",
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+		},
+		httpMultiHashPageSize: 1024,
+	}
+
+	for _, apply := range o {
+		if err := apply(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+func WithTokenVerify(v FnVerifyToken) Option {
+	return func(o *options) error {
+		o.VerifyToken = v
+		return nil
+	}
+}
+
+func WithMultiHashIterPageSize(l uint64) Option {
+	return func(o *options) error {
+		if l == 0 {
+			return fmt.Errorf("page size must be lager than 0")
+		}
+		o.httpMultiHashPageSize = l
+		return nil
+	}
+}
+
+func WithListenAddr(addr string) Option {
+	return func(o *options) error {
+		o.ListenAddr = addr
+		return nil
+	}
+}
+
+func WithReadTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.ReadTimeout = t
+		return nil
+	}
+}
+
+func WithWriteTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.WriteTimeout = t
+		return nil
+	}
+}

--- a/server/http_adv/server.go
+++ b/server/http_adv/server.go
@@ -1,0 +1,150 @@
+package http_adv
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/filecoin-project/index-provider/server/utils"
+
+	provider "github.com/filecoin-project/index-provider"
+	mhiter "github.com/filecoin-project/index-provider/server/http_mh_iter"
+	"github.com/filecoin-project/index-provider/supplier"
+	"github.com/gorilla/mux"
+	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+const announceAdvPath = "/advertisement"
+const HttpAdvToken = "HttpAdvToken"
+
+var log = logging.Logger("adv_http_server")
+
+type Server struct {
+	*options
+
+	e provider.Interface
+
+	s *http.Server
+	l net.Listener
+	r *mux.Router
+
+	mhs    map[string]provider.MultihashIterator
+	mhsMux sync.Mutex
+}
+
+func NewServer(e provider.Interface, o ...Option) (*Server, error) {
+	opts, err := newOptions(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{e: e, options: opts, mhs: make(map[string]provider.MultihashIterator)}
+
+	s.s = &http.Server{
+		Handler:      s,
+		ReadTimeout:  opts.ReadTimeout,
+		WriteTimeout: opts.WriteTimeout,
+	}
+
+	if s.l, err = net.Listen("tcp", opts.ListenAddr); err != nil {
+		return nil, err
+	}
+
+	s.r = mux.NewRouter().StrictSlash(true)
+	s.r.HandleFunc(announceAdvPath, s.handleAnnounceAdvertisement)
+
+	return s, nil
+}
+
+func (s *Server) handleAnnounceAdvertisement(w http.ResponseWriter, r *http.Request) {
+	var (
+		req AnnounceAdvReq
+		err error
+	)
+	if _, err = req.ReadFrom(r.Body); err != nil {
+		msg := fmt.Sprintf("failed to unmarshal request: %v", err)
+		log.Errorw(msg, "err", err)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	var advCid cid.Cid
+	var b64CtxID = base64.StdEncoding.EncodeToString(req.ContextID)
+
+	if !req.IsDel {
+		s.AddMultiHashIter(req.ContextID, mhiter.NewHttpMhIterator(&mhiter.HttpMhIterOption{
+			ReqID:    req.ReqID,
+			Url:      req.Url,
+			Token:    req.Token,
+			PageSize: s.options.httpMultiHashPageSize,
+		}, req.ContextID, req.Total))
+
+		if advCid, err = s.e.NotifyPut(r.Context(), req.ContextID, req.MetaData); err != nil {
+			log.Errorf("publish advertisement failed, contextID:%s, err:%v", b64CtxID, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	} else {
+		if advCid, err = s.e.NotifyPut(r.Context(), req.ContextID, req.MetaData); err != nil {
+			log.Errorf("publish advertisement failed, contextID:%s, err:%v", b64CtxID, err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	if err := utils.Respond(w, http.StatusOK, &AnnounceAdvRes{AdvId: advCid}); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.VerifyToken != nil {
+		if err := s.VerifyToken(r.Header.Get("Authorization")); err != nil {
+			msg := fmt.Sprintf("token veriry failed:%v", err)
+			log.Errorf(msg)
+			http.Error(w, msg, http.StatusUnauthorized)
+		}
+	}
+	s.r.ServeHTTP(w, r)
+}
+
+func (s *Server) AddMultiHashIter(contextID []byte, mhi provider.MultihashIterator) {
+	s.mhsMux.Lock()
+	defer s.mhsMux.Unlock()
+	s.mhs[string(contextID)] = mhi
+}
+
+func (s *Server) DelMultihashIter(contextID []byte) (isDel bool) {
+	s.mhsMux.Lock()
+	defer s.mhsMux.Unlock()
+	if _, isDel = s.mhs[string(contextID)]; isDel {
+		delete(s.mhs, string(contextID))
+	}
+	return isDel
+}
+
+func (s *Server) ListMultihashes(_ context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	s.mhsMux.Lock()
+	mhi, find := s.mhs[string(contextID)]
+	s.mhsMux.Unlock()
+
+	if !find {
+		return nil, supplier.ErrNotFound
+	}
+	return mhi, nil
+}
+
+func (s *Server) Start() error {
+	log.Infow("http advertisement server listening", "addr", s.l.Addr())
+	return s.s.Serve(s.l)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	log.Info("http advertisement server shutdown")
+	return s.s.Shutdown(ctx)
+}

--- a/server/http_mh_iter/http_mh_iter_test.go
+++ b/server/http_mh_iter/http_mh_iter_test.go
@@ -20,12 +20,12 @@ const (
 	ErrToken   = "TestErrToken"
 	Token      = "TestToken"
 	ContextID  = "TestContextID"
-	ListenAddr = "0.0.0.0:3105"
+	ListenAddr = "0.0.0.0:3107"
 	PageSize   = 101
 )
 
 func TestMhIter(t *testing.T) {
-	svr, _ := NewServer(
+	svr, err := NewServer(
 		WithTokenVerify(func(reqID string, token string) error {
 			if reqID == ReqID && token == Token {
 				return nil
@@ -34,6 +34,8 @@ func TestMhIter(t *testing.T) {
 		}),
 		WithListenAddr(ListenAddr),
 	)
+
+	require.NoError(t, err)
 
 	mhsCount := 1020
 	mhs := testutil.RandomMultihashes(t, rand.New(rand.NewSource(334455)), mhsCount)
@@ -88,9 +90,5 @@ func TestMhIter(t *testing.T) {
 	svrStartErrChan <- nil
 
 	require.NoError(t, svr.Shutdown(context.TODO()))
-
-	select {
-	case e := <-svrStartErrChan:
-		require.NoError(t, e)
-	}
+	require.NoError(t, <-svrStartErrChan)
 }

--- a/server/http_mh_iter/http_mh_iter_test.go
+++ b/server/http_mh_iter/http_mh_iter_test.go
@@ -1,0 +1,96 @@
+package http_mh_iter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/filecoin-project/index-provider/server/utils"
+	"github.com/filecoin-project/index-provider/testutil"
+	"github.com/stretchr/testify/require"
+	"io"
+	"strings"
+	"testing"
+	"time"
+
+	"math/rand"
+)
+
+const (
+	ReqID      = "TestReqID"
+	ErrToken   = "TestErrToken"
+	Token      = "TestToken"
+	ContextID  = "TestContextID"
+	ListenAddr = "0.0.0.0:3105"
+	PageSize   = 101
+)
+
+func TestMhIter(t *testing.T) {
+	svr, _ := NewServer(
+		WithTokenVerify(func(reqID string, token string) error {
+			if reqID == ReqID && token == Token {
+				return nil
+			}
+			return fmt.Errorf("unauthurized")
+		}),
+		WithListenAddr(ListenAddr),
+	)
+
+	mhsCount := 1020
+	mhs := testutil.RandomMultihashes(t, rand.New(rand.NewSource(334455)), mhsCount)
+	svr.AddMultiHashes([]byte(ContextID), mhs)
+
+	var svrStartErrChan = make(chan error, 1)
+	go func() {
+		svrStartErrChan <- svr.Start()
+	}()
+
+	opts := &HttpMhIterOption{
+		ReqID:    ReqID,
+		Url:      "http://" + ListenAddr,
+		Token:    ErrToken,
+		PageSize: PageSize,
+	}
+	time.Sleep(time.Millisecond * 100)
+
+	t.Run("TestUnauthorized", func(t *testing.T) {
+		httpMhIterWithErrToken := NewHttpMhIterator(opts, []byte(ContextID), uint64(mhsCount))
+		err := httpMhIterWithErrToken.nextPage()
+		require.Equal(t, errors.Is(err, utils.ErrUnauthorized), true)
+	})
+
+	opts.Token = Token
+	httpMhIter := NewHttpMhIterator(opts, []byte(ContextID), uint64(mhsCount))
+
+	t.Run("TestMultiHashIterator", func(t *testing.T) {
+		for i := 0; i < mhsCount; i++ {
+			mh, err := httpMhIter.Next()
+			require.NoError(t, err)
+			require.Equal(t, mhs[i], mh)
+		}
+	})
+
+	t.Run("TestNextEOF", func(t *testing.T) {
+		_, err := httpMhIter.Next()
+		require.Equal(t, errors.Is(err, io.EOF), true)
+	})
+
+	t.Run("TestNextPageEOF", func(t *testing.T) {
+		require.Equal(t, errors.Is(httpMhIter.nextPage(), io.EOF), true)
+	})
+
+	t.Run("TestRemove", func(t *testing.T) {
+		require.Equal(t, svr.DelMultiHashes([]byte("ContextIDNotExists")), false)
+		require.Equal(t, svr.DelMultiHashes([]byte(ContextID)), true)
+		_, err := NewHttpMhIterator(opts, []byte(ContextID), uint64(mhsCount)).Next()
+		require.Equal(t, strings.Contains(err.Error(), "not found"), true)
+
+	})
+	svrStartErrChan <- nil
+
+	require.NoError(t, svr.Shutdown(context.TODO()))
+
+	select {
+	case e := <-svrStartErrChan:
+		require.NoError(t, e)
+	}
+}

--- a/server/http_mh_iter/mh_iter.go
+++ b/server/http_mh_iter/mh_iter.go
@@ -1,0 +1,118 @@
+package http_mh_iter
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"github.com/filecoin-project/index-provider/server/utils"
+	"io"
+	"net/http"
+
+	provider "github.com/filecoin-project/index-provider"
+	"github.com/multiformats/go-multihash"
+)
+
+var _ provider.MultihashIterator = (*HttpMhIterator)(nil)
+
+type HttpMhIterOption struct {
+	ReqID, Url, Token string
+	PageSize          uint64
+}
+
+type HttpMhIterator struct {
+	HttpMhIterOption
+
+	contextID []byte
+	total     uint64
+
+	mhs []multihash.Multihash
+	pos uint64
+
+	invalid bool
+}
+
+func NewHttpMhIterator(opts *HttpMhIterOption, contextID []byte, total uint64) *HttpMhIterator {
+	if opts.PageSize == 0 {
+		opts.PageSize = defMulhashIterPageSize
+	}
+	hmi := &HttpMhIterator{
+		HttpMhIterOption: *opts,
+		total:            total,
+		contextID:        contextID,
+		mhs:              make([]multihash.Multihash, 0, total),
+	}
+	return hmi
+}
+
+func (it *HttpMhIterator) Next() (multihash.Multihash, error) {
+	if it.pos >= uint64(len(it.mhs)) {
+		if it.pos >= it.total {
+			return nil, io.EOF
+		}
+		if err := it.nextPage(); err != nil {
+			return nil, fmt.Errorf("load next page failed:%w", err)
+		}
+	}
+	mh := it.mhs[it.pos]
+	it.pos++
+	return mh, nil
+}
+
+func (it *HttpMhIterator) nextPage() error {
+	if it.total == uint64(len(it.mhs)) {
+		return io.EOF
+	}
+
+	if it.invalid {
+		return fmt.Errorf("invalid http multihash iterator")
+	}
+
+	var req = &nextPageRequest{
+		AdvReqID:  it.ReqID,
+		ContextID: it.contextID,
+		Start:     uint64(len(it.mhs)),
+		Count:     it.PageSize,
+	}
+
+	b64CtxID := base64.StdEncoding.EncodeToString(it.contextID)
+
+	var body = bytes.NewBuffer(nil)
+	if _, err := req.WriteTo(body); err != nil {
+		return fmt.Errorf("req to http.Body failed:%w", err)
+	}
+	httpReq, err := http.NewRequest(http.MethodPost, it.Url+nextPagePath, body)
+	if err != nil {
+		return fmt.Errorf("new http request failed:%w", err)
+	}
+
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Authorization", it.Token)
+	httpReq.Header.Set("ReqID", it.ReqID)
+
+	resp, err := (&http.Client{}).Do(httpReq)
+	if err != nil {
+		return fmt.Errorf("post next page request failed:%w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return utils.HttpStatusCodeErr(resp)
+	}
+
+	var res nextPageResponse
+	if _, err := res.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("parse nextPageResponse failed:%w", err)
+	}
+
+	var count = uint64(len(res.Mhs))
+	if count != req.Count {
+		if count > req.Count || count+req.Start != it.total {
+			it.invalid = true
+			return fmt.Errorf("requested multihash count not equal returns(%d != %d)", req.Count, count)
+		}
+	}
+	it.mhs = append(it.mhs, res.Mhs...)
+
+	log.Infof("multihash iterator load contextID:%s, from:%d, to:%d, success", b64CtxID, req.Start, req.Count)
+
+	return nil
+}

--- a/server/http_mh_iter/models.go
+++ b/server/http_mh_iter/models.go
@@ -1,0 +1,42 @@
+package http_mh_iter
+
+import (
+	"io"
+
+	"github.com/filecoin-project/index-provider/server/utils"
+	"github.com/multiformats/go-multihash"
+)
+
+var (
+	_ io.ReaderFrom = (*nextPageRequest)(nil)
+	_ io.ReaderFrom = (*nextPageResponse)(nil)
+	_ io.WriterTo   = (*nextPageRequest)(nil)
+	_ io.WriterTo   = (*nextPageResponse)(nil)
+)
+
+type nextPageRequest struct {
+	AdvReqID  string
+	ContextID []byte
+	Start     uint64
+	Count     uint64
+}
+
+type nextPageResponse struct {
+	Mhs []multihash.Multihash
+}
+
+func (req *nextPageRequest) WriteTo(w io.Writer) (n int64, err error) {
+	return utils.MarshalToJson(w, req)
+}
+
+func (req *nextPageRequest) ReadFrom(r io.Reader) (n int64, err error) {
+	return utils.UnmarshalAsJson(r, req)
+}
+
+func (res *nextPageResponse) WriteTo(w io.Writer) (n int64, err error) {
+	return utils.MarshalToJson(w, res)
+}
+
+func (res *nextPageResponse) ReadFrom(r io.Reader) (n int64, err error) {
+	return utils.UnmarshalAsJson(r, res)
+}

--- a/server/http_mh_iter/options.go
+++ b/server/http_mh_iter/options.go
@@ -1,0 +1,63 @@
+package http_mh_iter
+
+import (
+	"time"
+
+	"github.com/filecoin-project/index-provider/server/utils"
+)
+
+type (
+	FnVerifyToken func(string, string) error
+
+	Option func(*options) error
+
+	options struct {
+		utils.Options
+		verifyToken FnVerifyToken
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	opts := &options{
+		Options: utils.Options{
+			ListenAddr:   "0.0.0.0:3105",
+			ReadTimeout:  30 * time.Second,
+			WriteTimeout: 30 * time.Second,
+		},
+	}
+
+	for _, apply := range o {
+		if err := apply(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+func WithTokenVerify(v FnVerifyToken) Option {
+	return func(o *options) error {
+		o.verifyToken = v
+		return nil
+	}
+}
+
+func WithListenAddr(addr string) Option {
+	return func(o *options) error {
+		o.ListenAddr = addr
+		return nil
+	}
+}
+
+func WithReadTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.ReadTimeout = t
+		return nil
+	}
+}
+
+func WithWriteTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.WriteTimeout = t
+		return nil
+	}
+}

--- a/server/http_mh_iter/server.go
+++ b/server/http_mh_iter/server.go
@@ -1,0 +1,136 @@
+package http_mh_iter
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+
+	"github.com/filecoin-project/index-provider/server/utils"
+
+	"github.com/gorilla/mux"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/multiformats/go-multihash"
+)
+
+const nextPagePath = "/next_page"
+const defMulhashIterPageSize = 1000
+
+var log = logging.Logger("http_mh_iter")
+
+type Server struct {
+	*options
+
+	s *http.Server
+	l net.Listener
+	r *mux.Router
+
+	mhs   map[string][]multihash.Multihash
+	mhMux sync.Mutex
+}
+
+func NewServer(o ...Option) (*Server, error) {
+	opts, err := newOptions(o...)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &Server{mhs: make(map[string][]multihash.Multihash), options: opts}
+
+	s.s = &http.Server{
+		Handler:      s,
+		ReadTimeout:  opts.ReadTimeout,
+		WriteTimeout: opts.WriteTimeout,
+	}
+
+	if s.l, err = net.Listen("tcp", opts.ListenAddr); err != nil {
+		return nil, err
+	}
+
+	s.r = mux.NewRouter().StrictSlash(true)
+
+	s.r.HandleFunc(nextPagePath, s.handleNextPage)
+
+	return s, nil
+}
+
+func (s *Server) handleNextPage(w http.ResponseWriter, r *http.Request) {
+	var req = &nextPageRequest{}
+
+	if _, err := req.ReadFrom(r.Body); err != nil {
+		msg := fmt.Sprintf("failed to unmarshal request: %v", err)
+		log.Errorw(msg, "err", err)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	b64CtxID := base64.StdEncoding.EncodeToString(req.ContextID)
+
+	mhs, find := s.mhs[string(req.ContextID)]
+	if !find {
+		msg := fmt.Sprintf("context id : %s not found", b64CtxID)
+		log.Errorf(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	count := uint64(len(mhs))
+	if req.Start >= count {
+		msg := fmt.Sprintf("request context id(%s) mutihash out of range, start:%d > total:%d",
+			b64CtxID, req.Start, len(mhs))
+		log.Errorf(msg)
+		http.Error(w, msg, http.StatusBadRequest)
+		return
+	}
+
+	var end = req.Start + req.Count
+	if end > count {
+		end = count
+	}
+
+	if err := utils.Respond(w, http.StatusOK, &nextPageResponse{Mhs: mhs[req.Start:end]}); err != nil {
+		log.Errorw("failed to write response ", "err", err)
+		return
+	}
+
+	log.Infof("multihash iter server load contextID:%s, from:%d, to:%d, success", b64CtxID, req.Start, req.Count)
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.options.verifyToken != nil {
+		if err := s.verifyToken(r.Header.Get("ReqID"), r.Header.Get("Authorization")); err != nil {
+			msg := fmt.Sprintf("token veriry failed:%v", err)
+			log.Errorf(msg)
+			http.Error(w, msg, http.StatusUnauthorized)
+			return
+		}
+	}
+	s.r.ServeHTTP(w, r)
+}
+
+func (s *Server) AddMultiHashes(contextID []byte, mhs []multihash.Multihash) {
+	s.mhMux.Lock()
+	defer s.mhMux.Unlock()
+	s.mhs[string(contextID)] = mhs
+}
+
+func (s *Server) DelMultiHashes(contextID []byte) (find bool) {
+	s.mhMux.Lock()
+	defer s.mhMux.Unlock()
+	if _, find = s.mhs[string(contextID)]; find {
+		delete(s.mhs, string(contextID))
+	}
+	return find
+}
+
+func (s *Server) Start() error {
+	log.Infow("multihash interator http server listening", "addr", s.l.Addr())
+	return s.s.Serve(s.l)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	log.Info("multihash iterator http server shutdown")
+	return s.s.Shutdown(ctx)
+}

--- a/server/utils/err.go
+++ b/server/utils/err.go
@@ -1,0 +1,22 @@
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+var ErrUnauthorized = errors.New(http.StatusText(http.StatusUnauthorized))
+
+func HttpStatusCodeErr(resp *http.Response) error {
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed  to read response: %w", err)
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return fmt.Errorf("%s:%w", respBody, ErrUnauthorized)
+	}
+	statusText := http.StatusText(resp.StatusCode)
+	return fmt.Errorf("%s: %s", statusText, respBody)
+}

--- a/server/utils/io.go
+++ b/server/utils/io.go
@@ -1,0 +1,34 @@
+package utils
+
+import (
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"net/http"
+)
+
+func Respond(w http.ResponseWriter, statusCode int, body io.WriterTo) error {
+	w.WriteHeader(statusCode)
+	// Attempt to serialize body as JSON
+	if _, err := body.WriteTo(w); err != nil {
+		return err
+	}
+	return nil
+}
+
+func UnmarshalAsJson(r io.Reader, dst interface{}) (int64, error) {
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(body)), json.Unmarshal(body, dst)
+}
+
+func MarshalToJson(w io.Writer, src interface{}) (int64, error) {
+	body, err := json.Marshal(src)
+	if err != nil {
+		return 0, err
+	}
+	written, err := w.Write(body)
+	return int64(written), err
+}

--- a/server/utils/svr_option.go
+++ b/server/utils/svr_option.go
@@ -1,0 +1,9 @@
+package utils
+
+import "time"
+
+type Options struct {
+	ListenAddr   string
+	ReadTimeout  time.Duration
+	WriteTimeout time.Duration
+}


### PR DESCRIPTION
Hello, guys! We have made improvements on the proposal given our [pervious discussion](https://github.com/filecoin-project/index-provider/pull/226)(#226).
I would like to add a http server module(for facing advertisement requests), to index-provider. this new feature would satisfy what @masih pointed out:

> - it isolated in terms of code structure and remains application agnostic.
> - it is optional, e.g. explicitly enabled via some `engine.Option` or in a separate package with clear godocs explaining usage etc.
> - the publish HTTP request matches `schema.Advertisement` very closely.
> - the publish over HTTP either:
>   - supports pagination of multihashes, or
>   - a clear HTTP message size limit with TODOs and issues captured to introduce pagination in a separate PR.

#### Http MultiHash Iterator

```go
type HttpMhIterOption struct {
	ReqID, Url, Token string
	PageSize          uint64
}
type HttpMhIterator struct {
	HttpMhIterOption
	contextID []byte
	total     uint64
	mhs []multihash.Multihash
	pos uint64
	invalid bool
}
func (it *HttpMhIterator) nextPage() error
func (it *HttpMhIterator) Next() (multihash.Multihash, error) 
```

- `nextPage` load mutilashes from `Url`, then appened to `mhs`,  offset from `len(mhs)`, the count is specified by `PageSize`.
- `Next`, implementation of  `provider.MultihashIterator`. If `pos == len(mhs)` and `pos < total`, it calls `nextPage` automatically; if the `pos` reaches `total`, it returns a `io.EOF`.
- `ReqID`,  the id of http advertisment request,  the multihash iterator http server may verify the `ReqID`, it is optional.

#### Advertisement Http Server

Advertisement Server, handles the advertisement announcement requests. 
The request is defined as:

```go
	AnnounceAdvReq struct {
		ReqID string
		Token string // the multihash iterator server used to verify request
		Url       string // url to request multihashes
		ContextID []byte // advertisement context id
		Total     uint64 // total count of multihashes in the advertisement
		MetaData metadata.Metadata
		IsDel bool
	}
```

The advertisement server is defined as:
```go
type Server struct {
  ......
	mhs    map[string]provider.MultihashIterator
	e provider.Interface
}
func (s *Server) handleAnnounceAdvertisement(w http.ResponseWriter, r *http.Request)
func (s *Server) AddMultiHashIter(contextID []byte, mhi provider.MultihashIterator) 
func (s *Server) DelMultihashIter(contextID []byte) (isDel bool)
func (s *Server) ListMultihashes(_ context.Context, contextID []byte) (provider.MultihashIterator, error) 
```


- `handleAnnounceAdvertisement` handle advertisement requsts, the `AnnounceAdvReq` is convert to a `HttpMhIterator`, and stored in `mhs`, then call `engine.NotifyPut` to publish advertisement.
- `ListMultihashes` registered into `engine` by `engine.RegisterMultihashLister` for searching multihash iterators. it just find mulithash iterator in `mhs`
- `DelMultihashIter` remove httpMultihashIterator from `mhs`, when to remove is up to the your own policies.

#### Http Multihash Iterator Server

the third parties(may be venus-market), wants to send http advertisement request, may needs a http server to handle `nextPage` requests from `HttpMultiHashIterator`, here we provide a simple implementation.
```go
type Server struct {
	mhs   map[string][]multihash.Multihash
  ......
}
func (s *Server) handleNextPage(w http.ResponseWriter, r *http.Request) 
func (s *Server) AddMultiHashes(contextID []byte, mhs []multihash.Multihash)
func (s *Server) DelMultiHashes(contextID []byte) (find bool)
```



Thats all. Looking forward to your review and feedbacks!