### PR TITLE
Recover from corrupted cached chunks gracefully

### DIFF
--- a/engine/chunker/cached_chunker_api_test.go
+++ b/engine/chunker/cached_chunker_api_test.go
@@ -3,10 +3,16 @@ package chunker
 import (
 	"context"
 
+	"github.com/ipfs/go-datastore"
 	"github.com/ipld/go-ipld-prime"
 )
 
 // CountOverlap is exposed for testing purposes only.
 func (ls *CachedEntriesChunker) CountOverlap(ctx context.Context, link ipld.Link) (uint64, error) {
 	return ls.countOverlap(ctx, link)
+}
+
+// DSKey is exposed for testing purposes only.
+func DSKey(l ipld.Link) datastore.Key {
+	return dsKey(l)
 }


### PR DESCRIPTION
On start up, the index-provider engine instantiates an entry chunker and
restores any previously cached entries. If for whatever reason the cache
is corrupt the engine will fail to start up.

Since the cache is ephemeral anyway and can be re-generated recover
gracefully from corrupt cache by clearing it. Also add logging to let
the user know when the cache is cleared.

Note that the logic for clearing the chance is changed to remove every
key in the given datastore. Because, the previous logic only cleared the
successfully loaded entries. This meant it was possible for the
datastore size to grow larger than expected, where orphan cached entries
are left behind.

Fixes: https://github.com/filecoin-project/index-provider/issues/231
Relates to: https://github.com/filecoin-project/boost/issues/561