### PR TITLE
Bump version to `0.8.0` in preparation for release

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.7.0"
+  "version": "v0.8.0"
 }


### PR DESCRIPTION
Bump version to release fixes in caching mechanism mainly. Note the
version is changed from `0.7.0` to `0.8.0` since the changes being
tagged also include removal of the `cmd` submodule.