### PR TITLE
Add command to publish announce message via HTTP

### DIFF
--- a/cmd/provider/announce.go
+++ b/cmd/provider/announce.go
@@ -3,8 +3,10 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 
+	adminserver "github.com/filecoin-project/index-provider/server/admin/http"
 	"github.com/urfave/cli/v2"
 )
 
@@ -40,7 +42,13 @@ func announceCommand(cctx *cli.Context) error {
 		return errFromHttpResp(resp)
 	}
 
-	_, err = cctx.App.Writer.Write([]byte("Announced latest advertisement\n"))
+	var res adminserver.AnnounceRes
+	if _, err := res.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("received ok response from server but cannot decode response body. %v", err)
+	}
+	msg := fmt.Sprintf("Announced latest advertisement: %s\n", res.AdvId)
+
+	_, err = cctx.App.Writer.Write([]byte(msg))
 	return err
 }
 
@@ -73,6 +81,12 @@ func announceHttpCommand(cctx *cli.Context) error {
 		return errFromHttpResp(resp)
 	}
 
-	_, err = cctx.App.Writer.Write([]byte("Announced latest advertisement via HTTP\n"))
+	var res adminserver.AnnounceRes
+	if _, err := res.ReadFrom(resp.Body); err != nil {
+		return fmt.Errorf("received ok response from server but cannot decode response body. %v", err)
+	}
+	msg := fmt.Sprintf("Announced latest advertisement via HTTP: %s\n", res.AdvId)
+
+	_, err = cctx.App.Writer.Write([]byte(msg))
 	return err
 }

--- a/cmd/provider/announce.go
+++ b/cmd/provider/announce.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"net/http"
 
 	"github.com/urfave/cli/v2"
@@ -11,6 +13,13 @@ var AnnounceCmd = &cli.Command{
 	Usage:  "Publish an announcement message for the latest advertisement",
 	Flags:  announceFlags,
 	Action: announceCommand,
+}
+
+var AnnounceHttpCmd = &cli.Command{
+	Name:   "announce-http",
+	Usage:  "Publish an announcement message for the latest advertisement to a specific indexer via http",
+	Flags:  announceHttpFlags,
+	Action: announceHttpCommand,
 }
 
 func announceCommand(cctx *cli.Context) error {
@@ -24,11 +33,46 @@ func announceCommand(cctx *cli.Context) error {
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
+
 	// Handle failed requests
 	if resp.StatusCode != http.StatusOK {
 		return errFromHttpResp(resp)
 	}
 
 	_, err = cctx.App.Writer.Write([]byte("Announced latest advertisement\n"))
+	return err
+}
+
+func announceHttpCommand(cctx *cli.Context) error {
+	indexer := cctx.String("indexer")
+
+	params := map[string][]byte{
+		"indexer": []byte(indexer),
+	}
+	bodyData, err := json.Marshal(&params)
+	if err != nil {
+		return err
+	}
+	body := bytes.NewBuffer(bodyData)
+
+	req, err := http.NewRequestWithContext(cctx.Context, http.MethodPost, adminAPIFlagValue+"/admin/announcehttp", body)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	cl := &http.Client{}
+	resp, err := cl.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return errFromHttpResp(resp)
+	}
+
+	_, err = cctx.App.Writer.Write([]byte("Announced latest advertisement via HTTP\n"))
 	return err
 }

--- a/cmd/provider/flags.go
+++ b/cmd/provider/flags.go
@@ -8,6 +8,11 @@ var announceFlags = []cli.Flag{
 	adminAPIFlag,
 }
 
+var announceHttpFlags = []cli.Flag{
+	adminAPIFlag,
+	indexerFlag,
+}
+
 var daemonFlags = []cli.Flag{
 	carZeroLengthAsEOFFlag,
 	&cli.StringFlag{

--- a/cmd/provider/provider.go
+++ b/cmd/provider/provider.go
@@ -42,6 +42,7 @@ func run() int {
 		Version: version,
 		Commands: []*cli.Command{
 			AnnounceCmd,
+			AnnounceHttpCmd,
 			ConnectCmd,
 			DaemonCmd,
 			FindCmd,

--- a/engine/host_to_maddr.go
+++ b/engine/host_to_maddr.go
@@ -1,0 +1,43 @@
+package engine
+
+import (
+	"fmt"
+	"net"
+	"regexp"
+
+	"github.com/multiformats/go-multiaddr"
+)
+
+func parseAddrType(host string) string {
+	addr := net.ParseIP(host)
+	if addr == nil {
+		re, _ := regexp.Compile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+		if !re.MatchString(host) {
+			return ""
+		}
+		return "dns4"
+	}
+	if addr.To4() != nil {
+		return "ip4"
+	}
+	if addr.To16() != nil {
+		return "ip6"
+	}
+	return ""
+}
+
+func hostToMultiaddr(hostport string) (multiaddr.Multiaddr, error) {
+	host, port, err := net.SplitHostPort(hostport)
+	if err != nil {
+		port = "80"
+		host = hostport
+	}
+	if len(host) > 255 {
+		return nil, fmt.Errorf("host name length cannot exceed 255")
+	}
+	addrType := parseAddrType(host)
+	if addrType == "" {
+		return nil, fmt.Errorf("unrecognized address: %q", host)
+	}
+	return multiaddr.NewMultiaddr(fmt.Sprintf("/%s/%s/tcp/%s", addrType, host, port))
+}

--- a/engine/host_to_maddr_test.go
+++ b/engine/host_to_maddr_test.go
@@ -1,0 +1,49 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestHostToMultiaddr(t *testing.T) {
+	m, err := hostToMultiaddr("google.com")
+	require.NoError(t, err)
+	require.Equal(t, "/dns4/google.com/tcp/80", m.String())
+
+	m, err = hostToMultiaddr("192.168.1.0")
+	require.NoError(t, err)
+	require.Equal(t, "/ip4/192.168.1.0/tcp/80", m.String())
+
+	m, err = hostToMultiaddr("192.168.1.0:3104")
+	require.NoError(t, err)
+	require.Equal(t, "/ip4/192.168.1.0/tcp/3104", m.String())
+
+	m, err = hostToMultiaddr("0:0:0:0:0:0:0:1")
+	require.NoError(t, err)
+	require.Equal(t, "/ip6/::1/tcp/80", m.String())
+
+	m, err = hostToMultiaddr("ns.google.com:8888")
+	require.NoError(t, err)
+	require.Equal(t, "/dns4/ns.google.com/tcp/8888", m.String())
+
+	// Port too high.
+	_, err = hostToMultiaddr("ns.google.com:65537")
+	require.Error(t, err)
+
+	// Port too high.
+	_, err = hostToMultiaddr("10.1.1.44:99999")
+	require.Error(t, err)
+
+	// Bad character in DNS name.
+	_, err = hostToMultiaddr("foo/bar")
+	require.Error(t, err)
+
+	// DNS name ends with ".".
+	_, err = hostToMultiaddr("google.com.")
+	require.Error(t, err)
+
+	// DNS name begins with "-".
+	_, err = hostToMultiaddr("-google.com")
+	require.Error(t, err)
+}

--- a/server/admin/http/announce_handler.go
+++ b/server/admin/http/announce_handler.go
@@ -1,6 +1,8 @@
 package adminserver
 
 import (
+	"encoding/json"
+	"io"
 	"net/http"
 )
 
@@ -8,6 +10,35 @@ func (s *Server) announceHandler(w http.ResponseWriter, r *http.Request) {
 	err := s.e.PublishLatest(r.Context())
 	if err != nil {
 		log.Errorw("Could not republish latest advertisement", "err", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s *Server) announceHttpHandler(w http.ResponseWriter, r *http.Request) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		log.Errorw("failed reading import cidlist request", "err", err)
+		http.Error(w, "", http.StatusBadRequest)
+		return
+	}
+	var params map[string][]byte
+	err = json.Unmarshal(body, &params)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+	indexer, ok := params["indexer"]
+	if !ok {
+		http.Error(w, "missing indexer url in request", http.StatusBadRequest)
+		return
+	}
+
+	err = s.e.PublishLatestHTTP(r.Context(), string(indexer))
+	if err != nil {
+		log.Errorw("Could not publish latest advertisement via http", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}

--- a/server/admin/http/announce_handler.go
+++ b/server/admin/http/announce_handler.go
@@ -7,14 +7,16 @@ import (
 )
 
 func (s *Server) announceHandler(w http.ResponseWriter, r *http.Request) {
-	err := s.e.PublishLatest(r.Context())
+	adCid, err := s.e.PublishLatest(r.Context())
 	if err != nil {
 		log.Errorw("Could not republish latest advertisement", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Respond with successful announce result.
+	resp := &AnnounceRes{adCid}
+	respond(w, http.StatusOK, resp)
 }
 
 func (s *Server) announceHttpHandler(w http.ResponseWriter, r *http.Request) {
@@ -36,12 +38,14 @@ func (s *Server) announceHttpHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	err = s.e.PublishLatestHTTP(r.Context(), string(indexer))
+	adCid, err := s.e.PublishLatestHTTP(r.Context(), string(indexer))
 	if err != nil {
 		log.Errorw("Could not publish latest advertisement via http", "err", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	// Respond with successful announce result.
+	resp := &AnnounceRes{adCid}
+	respond(w, http.StatusOK, resp)
 }

--- a/server/admin/http/io.go
+++ b/server/admin/http/io.go
@@ -79,6 +79,14 @@ func (er *ConnectRes) ReadFrom(r io.Reader) (int64, error) {
 	return unmarshalAsJson(r, er)
 }
 
+func (er *AnnounceRes) WriteTo(w io.Writer) (int64, error) {
+	return marshalToJson(w, er)
+}
+
+func (er *AnnounceRes) ReadFrom(r io.Reader) (int64, error) {
+	return unmarshalAsJson(r, er)
+}
+
 func respond(w http.ResponseWriter, statusCode int, body io.WriterTo) {
 	w.WriteHeader(statusCode)
 	// Attempt to serialize body as JSON

--- a/server/admin/http/models.go
+++ b/server/admin/http/models.go
@@ -53,3 +53,10 @@ type (
 		Paths []string `json:"paths"`
 	}
 )
+
+type (
+	AnnounceRes struct {
+		// The CID of the advertisement announced as latest.
+		AdvId cid.Cid `json:"adv_id"`
+	}
+)

--- a/server/admin/http/server.go
+++ b/server/admin/http/server.go
@@ -43,6 +43,8 @@ func New(h host.Host, e *engine.Engine, cs *supplier.CarSupplier, o ...Option) (
 	// Set protocol handlers
 	r.HandleFunc("/admin/announce", s.announceHandler).
 		Methods(http.MethodPost)
+	r.HandleFunc("/admin/announcehttp", s.announceHttpHandler).
+		Methods(http.MethodPost)
 
 	r.HandleFunc("/admin/connect", s.connectHandler).
 		Methods(http.MethodPost).


### PR DESCRIPTION
The `announce-http` command manually announces the latest advertisement CID to a specific indexer over HTTP. This works whether the provider publishes advertisements over dtsync or httpsync.