### PR TITLE
Do not bother restoring cache when purge cache is set

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -92,21 +92,13 @@ func New(o ...Option) (*Engine, error) {
 //
 // See: Engine.Shutdown, chunker.NewCachedEntriesChunker, dtsync.NewPublisherFromExisting.
 func (e *Engine) Start(ctx context.Context) error {
+	var err error
 	// Create datastore entriesChunker
 	entriesCacheDs := dsn.Wrap(e.ds, datastore.NewKey(linksCachePath))
-	cachedChunker, err := chunker.NewCachedEntriesChunker(ctx, entriesCacheDs, e.entChunkSize, e.entCacheCap)
+	e.entriesChunker, err = chunker.NewCachedEntriesChunker(ctx, entriesCacheDs, e.entChunkSize, e.entCacheCap, e.purgeCache)
 	if err != nil {
 		return err
 	}
-
-	if e.purgeCache {
-		err := cachedChunker.Clear(ctx)
-		if err != nil {
-			return err
-		}
-	}
-
-	e.entriesChunker = cachedChunker
 
 	e.publisher, err = e.newPublisher()
 	if err != nil {


### PR DESCRIPTION
The existing behaviour will restore the cache regardless of whether the
purge-cache flag is set or not. The rationale for this behaviour was
that the Clear logic needed to know what caches to delete in the
first place.

This rationale no longer stands because of the changes to recovery from
corrupt cache introduced in earlier PRs. The Clear logic would delete
all entries in the datastore regardless to make sure that the datastore
size does not leak as a result of orphan cache entries for example.

The changes here, therefore, won't bother restoring the cache if it is
to be cleared.

Relates to:
 - https://github.com/filecoin-project/index-provider/issues/237