### PR TITLE
Cache links of a root entry instead of resolving them on the fly

### DIFF
--- a/engine/chunker/benchmark_test.go
+++ b/engine/chunker/benchmark_test.go
@@ -1,0 +1,47 @@
+package chunker_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine/chunker"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	"github.com/stretchr/testify/require"
+)
+
+func BenchmarkRestoreCache(b *testing.B) {
+	const chunkSize = 1
+	const capacity = 100
+	const mhCount = 500
+	const byteSize = capacity * mhCount * 256 / 8 // multicodec.Sha2_256
+
+	rng := rand.New(rand.NewSource(1413))
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	store := dssync.MutexWrap(datastore.NewMapDatastore())
+
+	// Populate the datastore with data.
+	subject, err := chunker.NewCachedEntriesChunker(ctx, store, chunkSize, capacity, false)
+	require.NoError(b, err)
+	for i := 0; i < capacity; i++ {
+		mhi := getRandomMhIterator(b, rng, mhCount)
+		chunk, err := subject.Chunk(ctx, mhi)
+		require.NoError(b, err)
+		require.NotNil(b, chunk)
+	}
+	require.NoError(b, subject.Close())
+
+	// Instantiate a cache which will restore data on start up.
+	b.Run("RestoreOnConstruction", func(b *testing.B) {
+		b.SetBytes(byteSize)
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			subject, err := chunker.NewCachedEntriesChunker(ctx, store, chunkSize, capacity, false)
+			require.NoError(b, err)
+			require.NoError(b, subject.Close())
+		}
+	})
+}

--- a/engine/chunker/cached_chunker_api_test.go
+++ b/engine/chunker/cached_chunker_api_test.go
@@ -12,7 +12,7 @@ func (ls *CachedEntriesChunker) CountOverlap(ctx context.Context, link ipld.Link
 	return ls.countOverlap(ctx, link)
 }
 
-// DSKey is exposed for testing purposes only.
-func DSKey(l ipld.Link) datastore.Key {
-	return dsKey(l)
+// RootPrefixedDSKey is exposed for testing purposes only.
+func RootPrefixedDSKey(l ipld.Link) datastore.Key {
+	return rootKeyPrefix.Child(dsKey(l))
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -25,7 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func RandomCids(t *testing.T, rng *rand.Rand, n int) []cid.Cid {
+func RandomCids(t testing.TB, rng *rand.Rand, n int) []cid.Cid {
 	prefix := schema.Linkproto.Prefix
 
 	cids := make([]cid.Cid, n)


### PR DESCRIPTION
The chunk cache only stored the root of a chunked entry chain. The cache
restore logic then traversed the DAG to resolve all child links. In a
case where the cache is large and the DAG is big it could be slow to
traverse the dag and resolve all the child links.

Instead of resolving them dynamically, store the child links with the
root link so that restoring the hash is fast and won't require
traversing the DAG. The trade-off however is slightly larger storage
consumption, where for each entry chain DAG a mapping of root link to
list of all links in the DAG is stored in the datastore.

Fixes: https://github.com/filecoin-project/index-provider/issues/237