### PR TITLE
Upgrade indexing dependencies

### DIFF
--- a/cmd/provider/internal/client_store.go
+++ b/cmd/provider/internal/client_store.go
@@ -84,8 +84,7 @@ func (s *ProviderClientStore) getNextChunkLink(ctx context.Context, target cid.C
 	if chunk.Next == nil {
 		return cid.Undef, nil
 	}
-	next := *chunk.Next
-	return next.(cidlink.Link).Cid, nil
+	return chunk.Next.(cidlink.Link).Cid, nil
 }
 
 func (s *ProviderClientStore) getEntriesChunk(ctx context.Context, target cid.Cid) (cid.Cid, []multihash.Multihash, error) {
@@ -102,8 +101,7 @@ func (s *ProviderClientStore) getEntriesChunk(ctx context.Context, target cid.Ci
 	if chunk.Next == nil {
 		next = cid.Undef
 	} else {
-		lnk := *chunk.Next
-		next = lnk.(cidlink.Link).Cid
+		next = chunk.Next.(cidlink.Link).Cid
 	}
 
 	return next, chunk.Entries, nil
@@ -139,7 +137,7 @@ func (s *ProviderClientStore) getAdvertisement(ctx context.Context, id cid.Cid) 
 
 	var prevCid cid.Cid
 	if ad.PreviousID != nil {
-		prevCid = (*ad.PreviousID).(cidlink.Link).Cid
+		prevCid = ad.PreviousID.(cidlink.Link).Cid
 	}
 
 	entriesCid := ad.Entries.(cidlink.Link).Cid

--- a/engine/chunker/cached_chunker_test.go
+++ b/engine/chunker/cached_chunker_test.go
@@ -291,7 +291,7 @@ func TestCachedEntriesChunker_OverlappingDagIsNotEvicted(t *testing.T) {
 	c2 := requireDecodeAsEntryChunk(t, c2Lnk, c2Raw)
 	requireChunkEntriesMatch(t, c2.Entries, extraMhs)
 	require.NotNil(t, c2.Next)
-	c2NextLnk := *c2.Next
+	c2NextLnk := c2.Next
 	require.Equal(t, c1Lnk, c2NextLnk)
 
 	c2NextRaw, err := subject.GetRawCachedChunk(ctx, c2NextLnk)
@@ -512,7 +512,7 @@ func listEntriesChain(t *testing.T, e *chunker.CachedEntriesChunker, root ipld.L
 		if chunk.Next == nil {
 			break
 		}
-		next = *chunk.Next
+		next = chunk.Next
 		require.NoError(t, err)
 	}
 	return links
@@ -533,7 +533,7 @@ func requireDecodeAllMultihashes(t *testing.T, l ipld.Link, ls ipld.LinkSystem) 
 		require.NoError(t, err)
 		mhs := chunk.Entries
 		if chunk.Next != nil {
-			mhs = append(mhs, requireDecodeAllMultihashes(t, *chunk.Next, ls)...)
+			mhs = append(mhs, requireDecodeAllMultihashes(t, chunk.Next, ls)...)
 		}
 		return mhs
 	}

--- a/engine/chunker/chain_chunker.go
+++ b/engine/chunker/chain_chunker.go
@@ -95,7 +95,7 @@ func newEntriesChunkNode(mhs []multihash.Multihash, next ipld.Link) (ipld.Node, 
 		Entries: mhs,
 	}
 	if next != nil {
-		chunk.Next = &next
+		chunk.Next = next
 	}
 	return chunk.ToNode()
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -546,7 +546,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, contextID []byte, md me
 	if prevAdvID != cid.Undef {
 		log.Info("Latest advertisement CID was undefined - no previous advertisement")
 		prev := ipld.Link(cidlink.Link{Cid: prevAdvID})
-		adv.PreviousID = &prev
+		adv.PreviousID = prev
 	}
 
 	// Sign the advertisement.

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -188,7 +188,7 @@ func listEntriesChainFromCache(t *testing.T, e *chunker.CachedEntriesChunker, ro
 		if chunk.Next == nil {
 			break
 		}
-		next = *chunk.Next
+		next = chunk.Next
 	}
 	return links
 }

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,9 @@ go 1.17
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
-	github.com/filecoin-project/go-legs v0.4.5
+	github.com/filecoin-project/go-legs v0.4.6
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/storetheindex v0.4.18-0.20220707005041-339598fdf36b
+	github.com/filecoin-project/storetheindex v0.4.18
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -442,9 +442,9 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3XrX59mQhT8U3p7nu86o=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-indexer-core v0.2.17/go.mod h1:M3jX8aaXgAsZf9IR2Uwvnri3Sw+RXrqUx6oQlUPqJeU=
-github.com/filecoin-project/go-legs v0.4.5 h1:ZaxURLNu5i9mQyXcDhjxunX2kDp+exaZ98UyIFTvBJ4=
-github.com/filecoin-project/go-legs v0.4.5/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-indexer-core v0.2.18/go.mod h1:BIsKVvT0X6H5+rma35+gGXVaS1TNN4LFuWfp646OPBA=
+github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
+github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
@@ -461,8 +461,8 @@ github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNd
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/storetheindex v0.4.18-0.20220707005041-339598fdf36b h1:pew7Gw9bSKdABVphmpk9V4JwrHwhVHJoCJ7Lmri0MJE=
-github.com/filecoin-project/storetheindex v0.4.18-0.20220707005041-339598fdf36b/go.mod h1:qAy1/CcUVROSxpc+CI+vYz2G/KMkM6bLr3iQLjuLJNM=
+github.com/filecoin-project/storetheindex v0.4.18 h1:cEfcgQLUbxwBUkDJORjc0hCwHHXyhliqw2SqVvPkIOk=
+github.com/filecoin-project/storetheindex v0.4.18/go.mod h1:PtaafEwDTPr7m9122ISL+9pHYDabF2QqKh5aHf4Janc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v0.0.0-20180327030543-2492fe189ae6/go.mod h1:1i71OnUq3iUe1ma7Lr6yG6/rjvM3emb6yoL7xLFzcVQ=
@@ -1193,7 +1193,7 @@ github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73 h1:TsyATB2ZRRQGTwafJdgEUQkmjOExRV0DNokcihZxbnQ=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
-github.com/ipld/go-storethehash v0.1.8/go.mod h1:Gh52e3JFIbzULuRAP6oPBbJ5jJCNlOakihQ5DVtCv14=
+github.com/ipld/go-storethehash v0.1.9/go.mod h1:Gh52e3JFIbzULuRAP6oPBbJ5jJCNlOakihQ5DVtCv14=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52 h1:QG4CGBqCeuBo6aZlGAamSkxWdgWfZGeE49eUOWJPA4c=
 github.com/ipsn/go-secp256k1 v0.0.0-20180726113642-9d62b9f0bc52/go.mod h1:fdg+/X9Gg4AsAIzWpEHwnqd+QY3b7lajxyjE1m4hkq4=


### PR DESCRIPTION
Upgrade to latest `go-legs` to fix an issue in `provider` CLI when given
HTTP provider multiaddr.

Upgrade to the latest storetheindex to take advantage of schema
simplifications. Reflect changes in the schema API.