### PR TITLE
Fix CLI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ and cannot be installed directly via `go install`
 -->
 
 ```shell
-go install github.com/filecoin-project/index-provider@latest
+go install github.com/filecoin-project/index-provider/cmd/provider@latest
 ```
 
 Alternatively, download the executables directly from


### PR DESCRIPTION
Executing `go install github.com/filecoin-project/index-provider@latest` returns `package github.com/filecoin-project/index-provider is not a main package`. 

The correct command should be `go install github.com/filecoin-project/index-provider/cmd/provider@latest`.