### PR TITLE
Support relative paths for car import

### DIFF
--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path/filepath"
 
 	"github.com/filecoin-project/index-provider/cardatatransfer"
 	"github.com/filecoin-project/index-provider/metadata"
@@ -75,8 +76,13 @@ func doImportCar(cctx *cli.Context) error {
 		return err
 	}
 
+	absCarPath, err := filepath.Abs(carPathFlagValue)
+	if err != nil {
+		return err
+	}
+
 	req := adminserver.ImportCarReq{
-		Path:     carPathFlagValue,
+		Path:     absCarPath,
 		Key:      importCarKey,
 		Metadata: mdBytes,
 	}


### PR DESCRIPTION
The CLI sends the car path to the daemon for import. The daemon may not resolve relative car paths if the CLI and daemon run in different working folders.

The proposed solution is the CLI to resolve the relative path to an absolute path before sending it to the daemon.