### PR TITLE
Calculate import cart key from the absolute car file path instead of raw path flag value

### DIFF
--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"path/filepath"
 
 	"github.com/filecoin-project/index-provider/cardatatransfer"
@@ -44,9 +43,12 @@ func beforeImportCar(cctx *cli.Context) error {
 		}
 		importCarKey = decoded
 	} else {
-		_, carName := path.Split(carPathFlagValue)
+		absCarPath, err := filepath.Abs(carPathFlagValue)
+		if err != nil {
+			return err
+		}
 		h := sha256.New()
-		h.Write([]byte(carName))
+		h.Write([]byte(absCarPath))
 		importCarKey = h.Sum(nil)
 	}
 	if cctx.IsSet(metadataFlag.Name) {

--- a/cmd/provider/import.go
+++ b/cmd/provider/import.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 
 	"github.com/filecoin-project/index-provider/cardatatransfer"
 	"github.com/filecoin-project/index-provider/metadata"
@@ -42,8 +43,9 @@ func beforeImportCar(cctx *cli.Context) error {
 		}
 		importCarKey = decoded
 	} else {
+		_, carName := path.Split(carPathFlagValue)
 		h := sha256.New()
-		h.Write([]byte(carPathFlagValue))
+		h.Write([]byte(carName))
 		importCarKey = h.Sum(nil)
 	}
 	if cctx.IsSet(metadataFlag.Name) {


### PR DESCRIPTION
If the import car key is not specified by the user, it is currently calculated as a hash of the unclean car path.

So different paths to the same file would produce a different key and hence a different ad for the very same content.

For example, importing:

my.car
./my.car
../my.car
/abs/path/to/my.car

will result in a different ad although these paths point to the same file.

It would be better if the absolute car file path is used to determine the import car key.