### PR TITLE
Mirror an existing provider with optional entries remap and CDN

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
-	github.com/filecoin-project/go-legs v0.4.6
+	github.com/filecoin-project/go-legs v0.4.7
 	github.com/filecoin-project/go-state-types v0.1.0
 	github.com/filecoin-project/storetheindex v0.4.18
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da

--- a/go.sum
+++ b/go.sum
@@ -443,8 +443,9 @@ github.com/filecoin-project/go-ds-versioning v0.1.1 h1:JiyBqaQlwC+UM0WhcBtVEeT3X
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-ds-versioning v0.1.1/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
 github.com/filecoin-project/go-indexer-core v0.2.18/go.mod h1:BIsKVvT0X6H5+rma35+gGXVaS1TNN4LFuWfp646OPBA=
-github.com/filecoin-project/go-legs v0.4.6 h1:u7sj4wE5l7An5wI3I3YnXcLikKAKxTbPk2vxd67lS9s=
 github.com/filecoin-project/go-legs v0.4.6/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
+github.com/filecoin-project/go-legs v0.4.7 h1:FOidNK0yd8a7UbhP9eGKYxWxD7F22AmBAyqVoXkNkNc=
+github.com/filecoin-project/go-legs v0.4.7/go.mod h1:JQ3hA6xpJdbR8euZ2rO0jkxaMxeidXf0LDnVuqPAe9s=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=

--- a/mirror/doc.go
+++ b/mirror/doc.go
@@ -1,0 +1,24 @@
+// Package mirror provides the ability to replicate the advertisement chain from an existing
+// provider with options to restructure the advertisement entries into schema.EntryChunk or HAMT.
+//
+// A Mirror is configurable via a set of options to control the generation of mirrored advertisements.
+// It can be configured to simply replicate the original advertisement chain without any changes,
+// explicitly re-sign the advertisement with the Mirror's identity, or restructure the advertisement
+// entries entirely. Note that any change to the structure of advertisement will require the ad to
+// be re-signed as the original signature will no longer be valid.
+//
+// A Mirror will also act as a CDN for the original advertisement chain by exposing a legs.Publisher
+// over GraphSync. The endpoint enables an indexer node to fetch the content associated with the
+// original chain of advertisement as well as the mirrored advertisement chain which may be
+// different.
+//
+// Upon starting a Mirror, when no prior mirrored advertisements exist, the initial mirroring
+// recursion depth is set to unlimited. When the initial limit is set to a value smaller than the
+// total number of available advertisements the very first mirrored advertisement will preserve the
+// original PreviousID link, even though the content corresponding to that link will not be hosted
+// by the mirror.
+//
+// Note that mirroring advertisements is one-to-one: for each original advertisement there will be
+// a mirrored one. This is not affected by optional remapping of entries. Future work will provide
+// the ability to also remap advertisements in addition to entries.
+package mirror

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -1,0 +1,396 @@
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"time"
+
+	dt "github.com/filecoin-project/go-data-transfer"
+	datatransfer "github.com/filecoin-project/go-data-transfer/impl"
+	dtnetwork "github.com/filecoin-project/go-data-transfer/network"
+	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
+	"github.com/filecoin-project/go-legs"
+	"github.com/filecoin-project/go-legs/dtsync"
+	"github.com/filecoin-project/index-provider/engine/chunker"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/ipfs/go-graphsync"
+	gsimpl "github.com/ipfs/go-graphsync/impl"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	logging "github.com/ipfs/go-log/v2"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/datamodel"
+	"github.com/ipld/go-ipld-prime/linking"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var log = logging.Logger("provider/mirror")
+
+// Mirror provides the ability to mirror the advertisement chain of an existing provider, with
+// options to restructure entries as EntryChunk chain or HAMT.
+//
+// Additionally, a mirror can also serve as a CDN for the original advertisement chain and its
+// entries. It exposes a GraphSync publisher endpoint from which ad chain can be synced.
+type Mirror struct {
+	*options
+	source  peer.AddrInfo
+	sub     *legs.Subscriber
+	pub     legs.Publisher
+	ls      ipld.LinkSystem
+	chunker *chunker.CachedEntriesChunker
+	cancel  context.CancelFunc
+}
+
+// New instantiates a new Mirror that mirrors ad chain from the given source provider.
+//
+// See: Mirror.Start, Mirror.Shutdown.
+func New(ctx context.Context, source peer.AddrInfo, o ...Option) (*Mirror, error) {
+	opts, err := newOptions(o...)
+	if err != nil {
+		return nil, err
+	}
+	m := &Mirror{
+		options: opts,
+		source:  source,
+		ls:      cidlink.DefaultLinkSystem(),
+	}
+	m.ls.StorageReadOpener = m.storageReadOpener
+	m.ls.StorageWriteOpener = m.storageWriteOpener
+
+	// Do not bother instantiating chunker if there is no entries remapping to be done.
+	if m.remapEntriesEnabled() {
+		if m.chunker, err = chunker.NewCachedEntriesChunker(
+			ctx, opts.ds,
+			opts.chunkCacheCap,
+			opts.chunkerFunc,
+			opts.chunkCachePurge); err != nil {
+			return nil, err
+		}
+	}
+
+	dtds := namespace.Wrap(opts.ds, datastore.NewKey("datatransfer"))
+	dm, gx, err := newDataTransfer(ctx, m.h, dtds, m.ls)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: make the publisher kind configurable just like we do for Engine.
+	m.pub, err = dtsync.NewPublisherFromExisting(dm, m.h, m.topic, m.ls)
+	if err != nil {
+		return nil, err
+	}
+	m.sub, err = legs.NewSubscriber(m.h, nil, m.ls, m.topic, nil, legs.DtManager(dm, gx))
+	if err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// TODO: add option to override this
+func newDataTransfer(ctx context.Context, host host.Host, ds datastore.Batching, ls ipld.LinkSystem) (dt.Manager, graphsync.GraphExchange, error) {
+	gn := gsnet.NewFromLibp2pHost(host)
+	gx := gsimpl.New(ctx, gn, ls)
+	dn := dtnetwork.NewFromLibp2pHost(host)
+	tp := gstransport.NewTransport(host.ID(), gx)
+	dm, err := datatransfer.NewDataTransfer(ds, dn, tp)
+	if err != nil {
+		return nil, nil, err
+	}
+	dtReady := make(chan error)
+	dm.OnReady(func(e error) { dtReady <- e })
+	if err := dm.Start(ctx); err != nil {
+		return nil, nil, err
+	}
+	if err := <-dtReady; err != nil {
+		return nil, nil, err
+	}
+	return dm, gx, nil
+}
+
+func (m *Mirror) Start() error {
+	ctx, cancel := context.WithCancel(context.Background())
+	m.cancel = cancel
+	go func() {
+		for {
+			var t time.Time
+			select {
+			case t = <-m.ticker.C:
+			case <-ctx.Done():
+				return
+			}
+			log := log.With("time", t)
+
+			mc, err := m.getLatestOriginalAdCid(ctx)
+
+			if err != nil {
+				log.Errorw("failed to get the latest mirrored cid", "err", err)
+				continue
+			}
+			log = log.With("latestMirroredCid", mc)
+
+			var syncedAdCids []cid.Cid
+			var sel ipld.Node
+			if cid.Undef.Equals(mc) {
+				sel = selectors.adsWithRecursionLimit(m.initAdRecurLimit)
+			} else {
+				sel = selectors.adsWithStopAt(selector.RecursionLimitNone(), cidlink.Link{Cid: mc})
+			}
+
+			_, err = m.sub.Sync(ctx, m.source.ID, cid.Undef, sel, m.source.Addrs[0],
+				legs.ScopedBlockHook(func(id peer.ID, c cid.Cid, actions legs.SegmentSyncActions) {
+					// TODO: set actions next segment link to ad previous id if it is present. For
+					//      now segmentation is disabled.
+					//       Here we could be encountering HAMT or Entry Chunk so picking the next
+					//       CID is not trivial; we probably should not use segmentation for HAMT
+					//       at all.
+
+					// Prepend to the list since the mirroring should start from the oldest ad first.
+					syncedAdCids = append([]cid.Cid{c}, syncedAdCids...)
+				}),
+				// Disable segmentation until the actions in hook are handled appropriately
+				legs.ScopedSegmentDepthLimit(-1),
+			)
+
+			if err != nil {
+				log.Errorw("Failed to sync source", "err", err)
+				continue
+			}
+
+			for _, adCid := range syncedAdCids {
+				err := m.mirror(ctx, adCid)
+				if err != nil {
+					log.Errorw("Failed to mirror ad", "cid", adCid, "err", err)
+					// TODO add an option on what to do if the mirroring of an ad failed?
+				}
+			}
+
+			syncedCount := len(syncedAdCids)
+			if syncedCount > 0 {
+				latestOriginal := syncedAdCids[syncedCount-1]
+				err = m.setLatestOriginalAdCid(ctx, latestOriginal)
+				if err != nil {
+					log.Errorw("Failed to store latest original ad cid", "cid", latestOriginal, "err", err)
+				}
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (m *Mirror) Shutdown() error {
+	if m.cancel != nil {
+		m.cancel()
+	}
+	return nil
+}
+
+func (m *Mirror) mirror(ctx context.Context, adCid cid.Cid) error {
+	log := log.With("originalAd", adCid)
+	ad, err := m.loadAd(ctx, adCid)
+	if err != nil {
+		return err
+	}
+	if err := ad.Validate(); err != nil {
+		log.Errorw("Original ad is invalid", "err", err)
+		return err
+	}
+
+	origSigner, err := ad.VerifySignature()
+	if err != nil {
+		log.Errorw("Original ad signature verification failed", "err", err)
+		return err
+	}
+	log = log.With("originalSigner", origSigner)
+
+	var adChanged bool
+	// Mirror link to previous ad.
+	wasPreviousID := ad.PreviousID
+	prevMirroredAdCid, err := m.getLatestMirroredAdCid(ctx)
+	if err != nil {
+		log.Errorw("Failed to get latest mirrored ad", "err", err)
+		return err
+	} else if !cid.Undef.Equals(prevMirroredAdCid) {
+		// Only override the original previousID link if there is a previously mirrored ad.
+		// This means that if mirroring starts from a partial original ad chain, the original link
+		// to previous ad will be preserved even though the ad that corresponds to it is not hosted
+		// by the mirror.
+		ad.PreviousID = cidlink.Link{Cid: prevMirroredAdCid}
+	}
+	adChanged = wasPreviousID != ad.PreviousID
+
+	// Mirror link to entries.
+	wasEntries := ad.Entries
+	entriesCid := ad.Entries.(cidlink.Link).Cid
+	if !ad.IsRm {
+		switch entriesCid {
+		case cid.Undef:
+			// advertisement is invalid? entries CID should never be cid.Undef for non-removal ads.
+			return errors.New("entries link is cid.Undef")
+		case schema.NoEntries.Cid:
+			// Nothing to do.
+		default:
+			// TODO: it is unfortunate that go-legs takes a single address here... this needs to be
+			//       fixed in go-legs.
+			_, err = m.sub.Sync(ctx, m.source.ID, entriesCid, selectors.entriesWithLimit(m.entriesRecurLimit), m.source.Addrs[0])
+			if err != nil {
+				log.Errorw("Failed to sync entries", "cid", entriesCid, "err", err)
+				return err
+			}
+			ad.Entries, err = m.remapEntries(ctx, ad.Entries)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	adChanged = adChanged || wasEntries != ad.Entries
+
+	// Only re-sign ad if the option is set or some content in the ad has changed.
+	if m.alwaysReSignAds || adChanged {
+		if err := ad.Sign(m.h.Peerstore().PrivKey(m.h.ID())); err != nil {
+			return err
+		}
+	}
+
+	// Sanity check that mirrored ad is still valid.
+	// At this moment in time ad validation just checks the max size of metadata and context ID
+	// neither of which should have been modified by mirroring.
+	// Nevertheless, validate the mirrored ad since ad validation logic may (and perhaps should)
+	// become more selective to check the fields that may be modified by mirroring like the
+	// entries link.
+	if err := ad.Validate(); err != nil {
+		return err
+	}
+
+	node, err := ad.ToNode()
+	if err != nil {
+		return err
+	}
+	mirroredAdLink, err := m.ls.Store(ipld.LinkContext{Ctx: ctx}, schema.Linkproto, node)
+	if err != nil {
+		return err
+	}
+
+	mirroredAdCid := mirroredAdLink.(cidlink.Link).Cid
+	if err = m.setLatestMirroredAdCid(ctx, mirroredAdCid); err != nil {
+		return err
+	}
+
+	if err := m.pub.UpdateRoot(ctx, mirroredAdCid); err != nil {
+		return err
+	}
+	log.Infow("Mirrored successfully", "originalAdCid", adCid, "mirroredAdCid", mirroredAdCid)
+	return nil
+}
+
+func (m *Mirror) storageReadOpener(lctx linking.LinkContext, lnk datamodel.Link) (io.Reader, error) {
+	if lnk == schema.NoEntries {
+		return nil, errors.New("no-entries CID is not retrievable")
+	}
+	ctx := lctx.Ctx
+	c := lnk.(cidlink.Link).Cid
+
+	val, err := m.ds.Get(ctx, datastore.NewKey(lnk.Binary()))
+	if err != nil && err != datastore.ErrNotFound {
+		return nil, err
+	}
+	if len(val) != 0 {
+		// Do not discriminate by what the link point to; both old ads old entries and new entries.
+		// This makes the mirror act as CDN for the original ad chain too.
+		return bytes.NewBuffer(val), err
+	}
+
+	// If remapping entries is not enabled then we do not have the blocks asked for.
+	if !m.remapEntriesEnabled() {
+		return nil, datastore.ErrNotFound
+	}
+
+	b, err := m.chunker.GetRawCachedChunk(ctx, lnk)
+	if err != nil {
+		return nil, err
+	}
+
+	if b == nil {
+		orig, err := m.getOriginalEntriesLinkFromMirror(ctx, lnk)
+		if err != nil {
+			log.Errorw("Failed to get original entries link from mirror link", "link", lnk, "err", err)
+			return nil, err
+		}
+		mhi, err := m.loadEntries(ctx, orig)
+		if err != nil {
+			return nil, err
+		}
+		chunkedLink, err := m.chunker.Chunk(ctx, mhi)
+		if err != nil {
+			return nil, err
+		}
+		if chunkedLink != lnk {
+			// TODO the chunker must have changed. Nothing to do; error out.
+			return nil, errors.New("chunked link does not match the mapping to original entry")
+		}
+	} else {
+		log.Debugw("Found cache entry for CID", "cid", c)
+	}
+
+	// FIXME: under high concurrency or small capacity it is likely enough for the cached entry to
+	//        get evicted before we get the chance to read it back. This is true in the current
+	//        engine implementation too.
+	val, err = m.chunker.GetRawCachedChunk(ctx, lnk)
+	if err != nil {
+		log.Errorf("Error fetching cached list for CID (%s): %s", c, err)
+		return nil, err
+	}
+	if len(val) == 0 {
+		return nil, datastore.ErrNotFound
+	}
+	return bytes.NewBuffer(val), nil
+}
+
+func (m *Mirror) storageWriteOpener(lctx linking.LinkContext) (io.Writer, linking.BlockWriteCommitter, error) {
+	buf := bytes.NewBuffer(nil)
+	return buf, func(lnk ipld.Link) error {
+		return m.ds.Put(lctx.Ctx, datastore.NewKey(lnk.Binary()), buf.Bytes())
+	}, nil
+}
+
+func (m *Mirror) remapEntries(ctx context.Context, original ipld.Link) (ipld.Link, error) {
+	if !m.remapEntriesEnabled() {
+		return original, nil
+	}
+	// Check if remapping should be skipped when the original entry kind matches the target kind.
+	if m.skipRemapOnEntriesTypeMatch {
+		entriesType, err := m.getEntriesPrototype(ctx, original)
+		if err != nil {
+			return nil, err
+		}
+		if entriesType == m.entriesRemapPrototype {
+			return original, nil
+		}
+	}
+
+	// Load the entries as multihash iterator.
+	mhi, err := m.loadEntries(ctx, original)
+	if err != nil {
+		return nil, err
+	}
+	// Use the chunker mechanism to re-generate entries as it supports both entry chunk chan and
+	// HAMT.
+	mirroredEntriesLink, err := m.chunker.Chunk(ctx, mhi)
+	if err != nil {
+		return nil, err
+	}
+	// Store a mapping between the remapped entries link and the original link.
+	// The remapping is used to load the original content in case it needs to be regenerated
+	// as a result of entry chunk cache eviction.
+	if err := m.setMirroredEntriesLink(ctx, mirroredEntriesLink, original); err != nil {
+		return nil, err
+	}
+	return mirroredEntriesLink, nil
+}

--- a/mirror/mirror_api_test.go
+++ b/mirror/mirror_api_test.go
@@ -1,0 +1,26 @@
+package mirror
+
+import (
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// GetTopicName is exposed for testing purposes only.
+func (m *Mirror) GetTopicName() string {
+	return m.topic
+}
+
+// RemapEntriesEnabled is exposed for testing purposes only.
+func (m *Mirror) RemapEntriesEnabled() bool {
+	return m.remapEntriesEnabled()
+
+}
+
+// EntriesRemapPrototype is exposed for testing purposes only.
+func (m *Mirror) EntriesRemapPrototype() schema.TypedPrototype {
+	return m.entriesRemapPrototype
+}
+
+// AlwaysReSignAds is exposed for testing purposes only.
+func (m *Mirror) AlwaysReSignAds() bool {
+	return m.alwaysReSignAds
+}

--- a/mirror/mirror_env_test.go
+++ b/mirror/mirror_env_test.go
@@ -1,0 +1,228 @@
+package mirror_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/filecoin-project/go-legs/dtsync"
+	provider "github.com/filecoin-project/index-provider"
+	"github.com/filecoin-project/index-provider/engine"
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/index-provider/mirror"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	hamt "github.com/ipld/go-ipld-adl-hamt"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/storage/memstore"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peerstore"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+type testEnv struct {
+	sourceHost host.Host
+	source     *engine.Engine
+	sourceMhs  map[string][]multihash.Multihash
+
+	mirror            *mirror.Mirror
+	mirrorHost        host.Host
+	mirrorSync        *dtsync.Sync
+	mirrorSyncHost    host.Host
+	mirrorSyncLs      ipld.LinkSystem
+	mirrorSyncer      *dtsync.Syncer
+	mirrorSyncLsStore *memstore.Store
+}
+
+func (te *testEnv) startMirror(t *testing.T, ctx context.Context, opts ...mirror.Option) {
+	var err error
+	te.mirrorHost, err = libp2p.New()
+	require.NoError(t, err)
+	// Override the host, since test environment needs explicit access to it.
+	opts = append(opts, mirror.WithHost(te.mirrorHost))
+	te.mirror, err = mirror.New(ctx, te.sourceAddrInfo(t), opts...)
+	require.NoError(t, err)
+	require.NoError(t, te.mirror.Start())
+	t.Cleanup(func() { require.NoError(t, te.mirror.Shutdown()) })
+
+	te.mirrorSyncHost, err = libp2p.New()
+	require.NoError(t, err)
+	te.mirrorSyncHost.Peerstore().AddAddrs(te.mirrorHost.ID(), te.mirrorHost.Addrs(), peerstore.PermanentAddrTTL)
+
+	te.mirrorSyncLsStore = &memstore.Store{}
+	te.mirrorSyncLs = cidlink.DefaultLinkSystem()
+	te.mirrorSyncLs.SetReadStorage(te.mirrorSyncLsStore)
+	te.mirrorSyncLs.SetWriteStorage(te.mirrorSyncLsStore)
+
+	te.mirrorSync, err = dtsync.NewSync(te.mirrorSyncHost, dssync.MutexWrap(datastore.NewMapDatastore()), te.mirrorSyncLs, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, te.mirrorSync.Close()) })
+	te.mirrorSyncer = te.mirrorSync.NewSyncer(te.mirrorHost.ID(), te.mirror.GetTopicName(), nil)
+}
+
+func (te *testEnv) sourceAddrInfo(t *testing.T) peer.AddrInfo {
+	require.NotNil(t, te.sourceHost, "start source first")
+	return te.sourceHost.Peerstore().PeerInfo(te.sourceHost.ID())
+}
+
+func (te *testEnv) startSource(t *testing.T, ctx context.Context, opts ...engine.Option) {
+	var err error
+	te.sourceHost, err = libp2p.New()
+	require.NoError(t, err)
+	// Override the host, since test environment needs explicit access to it.
+	opts = append(opts, engine.WithHost(te.sourceHost))
+	te.source, err = engine.New(opts...)
+	require.NoError(t, err)
+	t.Cleanup(func() { require.NoError(t, te.source.Shutdown()) })
+	te.sourceMhs = make(map[string][]multihash.Multihash)
+	te.source.RegisterMultihashLister(te.listMultihashes)
+	require.NoError(t, te.source.Start(ctx))
+}
+
+func (te *testEnv) putAdOnSource(t *testing.T, ctx context.Context, ctxID []byte, mhs []multihash.Multihash, md metadata.Metadata) cid.Cid {
+	te.sourceMhs[string(ctxID)] = mhs
+	adCid, err := te.source.NotifyPut(ctx, ctxID, md)
+	require.NoError(t, err)
+	return adCid
+}
+
+func (te *testEnv) removeAdOnSource(t *testing.T, ctx context.Context, ctxID []byte) cid.Cid {
+	adCid, err := te.source.NotifyRemove(ctx, ctxID)
+	require.NoError(t, err)
+	return adCid
+}
+
+func (te *testEnv) listMultihashes(_ context.Context, contextID []byte) (provider.MultihashIterator, error) {
+	mhs, ok := te.sourceMhs[string(contextID)]
+	if !ok {
+		return nil, fmt.Errorf("no multihashes found for context ID: %s", string(contextID))
+	}
+	return provider.SliceMultihashIterator(mhs), nil
+}
+
+func (te *testEnv) requireAdChainMirroredRecursively(t *testing.T, ctx context.Context, originalAdCid, mirroredAdCid cid.Cid) {
+	// Load Ads
+	original, err := te.source.GetAdv(ctx, originalAdCid)
+	require.NoError(t, err)
+	mirrored, err := te.syncMirrorAd(ctx, mirroredAdCid)
+	require.NoError(t, err)
+
+	te.requireAdMirrored(t, ctx, original, mirrored)
+
+	// Assert previous ad is mirrored as expected.
+	if original.PreviousID == nil {
+		require.Nil(t, mirrored.PreviousID)
+		return
+	}
+	te.requireAdChainMirroredRecursively(t, ctx, original.PreviousID.(cidlink.Link).Cid, mirrored.PreviousID.(cidlink.Link).Cid)
+}
+
+func (te *testEnv) requireAdMirrored(t *testing.T, ctx context.Context, original, mirrored *schema.Advertisement) {
+	// Assert fields that should have remained the same are identical.
+	require.Equal(t, original.IsRm, mirrored.IsRm)
+	require.Equal(t, original.Provider, mirrored.Provider)
+	require.Equal(t, original.Metadata, mirrored.Metadata)
+	require.Equal(t, original.Addresses, mirrored.Addresses)
+	require.Equal(t, original.ContextID, mirrored.ContextID)
+
+	gotSigner, err := mirrored.VerifySignature()
+	require.NoError(t, err)
+
+	// In the test environment the signer of ad is either the source or the mirror depending on
+	// the mirroring options or weather the PreviousID or Entries link is changed in comparison with
+	// the original ad.
+	// Assert one or the other accordingly.
+	var wantSigner peer.ID
+	if te.mirror.AlwaysReSignAds() || original.Entries != mirrored.Entries || original.PreviousID != mirrored.PreviousID {
+		wantSigner = te.mirrorHost.ID()
+	} else {
+		wantSigner = te.sourceHost.ID()
+	}
+	require.Equal(t, wantSigner, gotSigner)
+
+	// Assert entries are mirrored as expected
+	te.requireEntriesMirrored(t, ctx, original.ContextID, original.Entries, mirrored.Entries)
+}
+
+func (te *testEnv) requireEntriesMirrored(t *testing.T, ctx context.Context, contextID []byte, originalEntriesLink, mirroredEntriesLink ipld.Link) {
+
+	if originalEntriesLink == schema.NoEntries {
+		require.Equal(t, schema.NoEntries, mirroredEntriesLink)
+		return
+	}
+
+	// Entries link should never be nil.
+	require.NotNil(t, originalEntriesLink)
+	require.NotNil(t, mirroredEntriesLink)
+
+	// Assert that the entries are sync-able from mirror which will implicitly assert that the
+	// returned entries indeed correspond to the given link via block digest verification.
+	err := te.mirrorSyncer.Sync(ctx, mirroredEntriesLink.(cidlink.Link).Cid, selectorparse.CommonSelector_ExploreAllRecursively)
+	require.NoError(t, err)
+
+	if !te.mirror.RemapEntriesEnabled() {
+		require.Equal(t, originalEntriesLink, mirroredEntriesLink)
+		return
+	}
+
+	wantMhs := te.sourceMhs[string(contextID)]
+
+	var mirroredMhIter provider.MultihashIterator
+	switch te.mirror.EntriesRemapPrototype() {
+	case schema.EntryChunkPrototype:
+		mirroredMhIter, err = provider.EntryChunkMultihashIterator(mirroredEntriesLink, te.mirrorSyncLs)
+		require.NoError(t, err)
+	case hamt.HashMapRootPrototype:
+		n, err := te.mirrorSyncLs.Load(ipld.LinkContext{Ctx: ctx}, mirroredEntriesLink, hamt.HashMapRootPrototype)
+		require.NoError(t, err)
+		root := bindnode.Unwrap(n).(*hamt.HashMapRoot)
+		mirroredMhIter = provider.HamtMultihashIterator(root, te.mirrorSyncLs)
+		require.NoError(t, err)
+	default:
+		t.Fatal("unknown entries remap prototype", te.mirror.EntriesRemapPrototype())
+	}
+
+	var gotMhs []multihash.Multihash
+	for {
+		next, err := mirroredMhIter.Next()
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		gotMhs = append(gotMhs, next)
+	}
+	require.ElementsMatch(t, wantMhs, gotMhs)
+}
+
+func (te *testEnv) syncFromMirrorRecursively(ctx context.Context, c cid.Cid) error {
+	if exists, err := te.mirrorSyncLsStore.Has(ctx, cidlink.Link{Cid: c}.Binary()); err != nil {
+		return err
+	} else if exists {
+		return nil
+	}
+	if te.mirrorSyncer == nil {
+		return errors.New("start mirror first")
+	}
+	return te.mirrorSyncer.Sync(ctx, c, selectorparse.CommonSelector_MatchPoint)
+}
+
+func (te *testEnv) syncMirrorAd(ctx context.Context, adCid cid.Cid) (*schema.Advertisement, error) {
+	if err := te.syncFromMirrorRecursively(ctx, adCid); err != nil {
+		return nil, err
+	}
+	n, err := te.mirrorSyncLs.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: adCid}, schema.AdvertisementPrototype)
+	if err != nil {
+		return nil, err
+	}
+	return schema.UnwrapAdvertisement(n)
+}

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -1,0 +1,318 @@
+package mirror_test
+
+import (
+	"context"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine"
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/filecoin-project/index-provider/mirror"
+	"github.com/filecoin-project/index-provider/testutil"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	selectorparse "github.com/ipld/go-ipld-prime/traversal/selector/parse"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testContextTimeout  = 10 * time.Second
+	testEventualTimeout = testContextTimeout / 2
+	testCheckInterval   = testEventualTimeout / 10
+	testRandomSeed      = 1413
+)
+
+func newTestContext(t *testing.T) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func TestMirror_PutAdIsMirrored(t *testing.T) {
+	ctx := newTestContext(t)
+	rng := rand.New(rand.NewSource(testRandomSeed))
+	wantMhs := testutil.RandomMultihashes(t, rng, 42)
+	wantCtxID := []byte("fish")
+	wantMetadata := metadata.New(metadata.Bitswap{}, &metadata.GraphsyncFilecoinV1{
+		PieceCID:     testutil.RandomCids(t, rng, 1)[0],
+		VerifiedDeal: true,
+	})
+
+	te := &testEnv{}
+	// Start original index provider
+	te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+
+	// Publish an advertisement on original provider.
+	originalAdCid := te.putAdOnSource(t, ctx, wantCtxID, wantMhs, wantMetadata)
+
+	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+
+	// Eventually require some head ad CID at the mirror.
+	var gotMirroredHeadCid cid.Cid
+	var err error
+	require.Eventually(t, func() bool {
+		gotMirroredHeadCid, err = te.mirrorSyncer.GetHead(ctx)
+		return err == nil && !cid.Undef.Equals(gotMirroredHeadCid)
+	}, testEventualTimeout, testCheckInterval, "err: %v", err)
+
+	// Assert mirrored correctly.
+	te.requireAdChainMirroredRecursively(t, ctx, originalAdCid, gotMirroredHeadCid)
+}
+
+func TestMirror_IsAlsoCdnForOriginalAds(t *testing.T) {
+	ctx := newTestContext(t)
+	rng := rand.New(rand.NewSource(testRandomSeed))
+	md := metadata.New(metadata.Bitswap{})
+
+	te := &testEnv{}
+	// Start original index provider
+	te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+
+	// Publish a bunch of ads on the original provider
+	ad1 := te.putAdOnSource(t, ctx, []byte("ad1"), testutil.RandomMultihashes(t, rng, 3), md)
+	ad2 := te.putAdOnSource(t, ctx, []byte("ad2"), testutil.RandomMultihashes(t, rng, 4), md)
+	ad3 := te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 5), md)
+	ad4 := te.removeAdOnSource(t, ctx, []byte("ad1"))
+
+	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+
+	// Eventually require all original ads to be retrievable from the mirror.
+	var err error
+	require.Eventually(t, func() bool {
+		if err = te.mirrorSyncer.Sync(ctx, ad1, selectorparse.CommonSelector_MatchPoint); err != nil {
+			return false
+		}
+		if err = te.mirrorSyncer.Sync(ctx, ad2, selectorparse.CommonSelector_MatchPoint); err != nil {
+			return false
+		}
+		if err = te.mirrorSyncer.Sync(ctx, ad3, selectorparse.CommonSelector_MatchPoint); err != nil {
+			return false
+		}
+		if err = te.mirrorSyncer.Sync(ctx, ad4, selectorparse.CommonSelector_MatchPoint); err != nil {
+			return false
+		}
+		return true
+	}, testEventualTimeout, testCheckInterval, "err: %v", err)
+}
+
+func TestMirror_FormsExpectedAdChain(t *testing.T) {
+	ctx := newTestContext(t)
+	rng := rand.New(rand.NewSource(testRandomSeed))
+	md := metadata.New(metadata.Bitswap{})
+
+	te := &testEnv{}
+	// Start original index provider
+	te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+
+	// Publish a bunch of ads on the original provider
+	_ = te.putAdOnSource(t, ctx, []byte("ad1"), testutil.RandomMultihashes(t, rng, 3), md)
+	_ = te.putAdOnSource(t, ctx, []byte("ad2"), testutil.RandomMultihashes(t, rng, 4), md)
+	_ = te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 5), md)
+	originalHeadAdCid := te.removeAdOnSource(t, ctx, []byte("ad1"))
+
+	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+
+	// Await until the entire chain is mirrored; this is done by checking if the head mirrored ad
+	// is a removal.
+	var gotMirroredHeadAdCid cid.Cid
+	var err error
+	require.Eventually(t, func() bool {
+		gotMirroredHeadAdCid, err = te.mirrorSyncer.GetHead(ctx)
+		if err != nil || cid.Undef.Equals(gotMirroredHeadAdCid) {
+			return false
+		}
+		ad, err := te.syncMirrorAd(ctx, gotMirroredHeadAdCid)
+		if err != nil {
+			return false
+		}
+		// The head ad should be a removal since that's the last ad published by the original
+		// provider.
+		return ad.IsRm
+	}, testEventualTimeout, testCheckInterval, "err: %v", err)
+
+	// Read each individual mirrored ad and assert it is mirrored as expected.
+	te.requireAdChainMirroredRecursively(t, ctx, originalHeadAdCid, gotMirroredHeadAdCid)
+}
+
+func TestMirror_FormsExpectedAdChainRemap(t *testing.T) {
+	tests := []struct {
+		name          string
+		mirrorOptions []mirror.Option
+	}{
+		{
+			name: "unchanged",
+		},
+		{
+			name:          "hamt_murmur_3_3",
+			mirrorOptions: []mirror.Option{mirror.WithHamtRemapper(multihash.MURMUR3X64_64, 3, 3)},
+		},
+		{
+			name:          "hamt_id_3_1",
+			mirrorOptions: []mirror.Option{mirror.WithHamtRemapper(multihash.IDENTITY, 3, 1)},
+		},
+		{
+			name:          "entry_chunk_1",
+			mirrorOptions: []mirror.Option{mirror.WithEntryChunkRemapper(1)},
+		},
+		{
+			name:          "entry_chunk_1000",
+			mirrorOptions: []mirror.Option{mirror.WithEntryChunkRemapper(1000)},
+		},
+		{
+			name:          "hamt_murmur_3_3_reSign",
+			mirrorOptions: []mirror.Option{mirror.WithHamtRemapper(multihash.MURMUR3X64_64, 3, 3), mirror.WithAlwaysReSignAds(true)},
+		},
+		{
+			name:          "hamt_id_3_1_reSign",
+			mirrorOptions: []mirror.Option{mirror.WithHamtRemapper(multihash.IDENTITY, 3, 1), mirror.WithAlwaysReSignAds(true)},
+		},
+		{
+			name:          "entry_chunk_1_reSign",
+			mirrorOptions: []mirror.Option{mirror.WithEntryChunkRemapper(1), mirror.WithAlwaysReSignAds(true)},
+		},
+		{
+			name:          "entry_chunk_1000_reSign",
+			mirrorOptions: []mirror.Option{mirror.WithEntryChunkRemapper(1000), mirror.WithAlwaysReSignAds(true)},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := newTestContext(t)
+			rng := rand.New(rand.NewSource(testRandomSeed))
+			md := metadata.New(metadata.Bitswap{})
+
+			te := &testEnv{}
+			// Start original index provider
+			te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+
+			// Publish a bunch of ads on the original provider
+			_ = te.putAdOnSource(t, ctx, []byte("ad1"), testutil.RandomMultihashes(t, rng, 1), md)
+			_ = te.putAdOnSource(t, ctx, []byte("ad2"), testutil.RandomMultihashes(t, rng, 400), md)
+			_ = te.removeAdOnSource(t, ctx, []byte("ad1"))
+			_ = te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 1), md)
+			_ = te.putAdOnSource(t, ctx, []byte("ad4"), testutil.RandomMultihashes(t, rng, 2), md)
+			_ = te.removeAdOnSource(t, ctx, []byte("ad2"))
+			originalHeadAdCid := te.putAdOnSource(t, ctx, []byte("ad5"), testutil.RandomMultihashes(t, rng, 7), md)
+
+			test.mirrorOptions = append(test.mirrorOptions, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+			te.startMirror(t, ctx, test.mirrorOptions...)
+
+			// Await until the entire chain is mirrored; this is done by checking if the head mirrored ad
+			// is a removal.
+			var gotMirroredHeadAdCid cid.Cid
+			var err error
+			require.Eventually(t, func() bool {
+				gotMirroredHeadAdCid, err = te.mirrorSyncer.GetHead(ctx)
+				if err != nil || cid.Undef.Equals(gotMirroredHeadAdCid) {
+					return false
+				}
+				// Check the context is the latest originally published ad context as a way to
+				// assert that the entire ad chain is mirrored.
+				var ad *schema.Advertisement
+				ad, err = te.syncMirrorAd(ctx, gotMirroredHeadAdCid)
+				return err == nil && string(ad.ContextID) == "ad5"
+			}, testEventualTimeout, testCheckInterval, "err: %v", err)
+
+			// Read each individual mirrored ad and assert it is mirrored as expected.
+			te.requireAdChainMirroredRecursively(t, ctx, originalHeadAdCid, gotMirroredHeadAdCid)
+		})
+	}
+}
+
+func TestMirror_PreviousIDIsPreservedOnStartFromPartialAdChain(t *testing.T) {
+	ctx := newTestContext(t)
+	rng := rand.New(rand.NewSource(testRandomSeed))
+	md := metadata.New(metadata.Bitswap{})
+
+	te := &testEnv{}
+	// Start source and publish 3 ads.
+	te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+	originalACid := te.putAdOnSource(t, ctx, []byte("ad1"), testutil.RandomMultihashes(t, rng, 1), md)
+	originalBCid := te.putAdOnSource(t, ctx, []byte("ad2"), testutil.RandomMultihashes(t, rng, 2), md)
+	orignalHeadCid := te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 3), md)
+
+	// Start mirror with maximum initial depth of 2.
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)), mirror.WithInitialAdRecursionLimit(selector.RecursionLimitDepth(2)))
+
+	var gotMirroredHeadAdCid cid.Cid
+	var err error
+	require.Eventually(t, func() bool {
+		gotMirroredHeadAdCid, err = te.mirrorSyncer.GetHead(ctx)
+		if err != nil || cid.Undef.Equals(gotMirroredHeadAdCid) {
+			return false
+		}
+		// Check the context is the latest originally published ad context as a way to
+		// assert that the entire ad chain is mirrored.
+		var ad *schema.Advertisement
+		ad, err = te.syncMirrorAd(ctx, gotMirroredHeadAdCid)
+		return err == nil && string(ad.ContextID) == "ad3"
+	}, testEventualTimeout, testCheckInterval, "err: %v", err)
+
+	// Load head and assert it is mirrored correctly.
+	original, err := te.source.GetAdv(ctx, orignalHeadCid)
+	require.NoError(t, err)
+	mirrored, err := te.syncMirrorAd(ctx, gotMirroredHeadAdCid)
+	require.NoError(t, err)
+	te.requireAdMirrored(t, ctx, original, mirrored)
+
+	// Load ad before head and assert it is mirrored
+	original, err = te.source.GetAdv(ctx, originalBCid)
+	require.NoError(t, err)
+	mirrored, err = te.syncMirrorAd(ctx, mirrored.PreviousID.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	te.requireAdMirrored(t, ctx, original, mirrored)
+
+	// Assert mirrored previousID is same as original
+	require.Equal(t, original.PreviousID, mirrored.PreviousID)
+
+	// Assert the mirror does not store the earliest ad nor is a CDN for it.
+	// Note that we can't explicitly assert not found error since the final error returned depends
+	// entirely on the order of concurrent interactions and based on the intermittent CI failures it
+	// is not reproducible.
+	err = te.syncFromMirrorRecursively(ctx, mirrored.PreviousID.(cidlink.Link).Cid)
+	require.NotNil(t, err)
+	err = te.syncFromMirrorRecursively(ctx, originalACid)
+	require.NotNil(t, err)
+}
+
+func TestMirror_MirrorsAdsIdenticallyWhenConfiguredTo(t *testing.T) {
+	ctx := newTestContext(t)
+	rng := rand.New(rand.NewSource(testRandomSeed))
+	md := metadata.New(metadata.Bitswap{})
+
+	te := &testEnv{}
+	// Start source and publish 3 ads.
+	te.startSource(t, ctx, engine.WithPublisherKind(engine.DataTransferPublisher))
+	_ = te.putAdOnSource(t, ctx, []byte("ad1"), testutil.RandomMultihashes(t, rng, 1), md)
+	_ = te.putAdOnSource(t, ctx, []byte("ad2"), testutil.RandomMultihashes(t, rng, 2), md)
+	_ = te.removeAdOnSource(t, ctx, []byte("ad1"))
+	originalHeadCid := te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 3), md)
+
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)), mirror.WithAlwaysReSignAds(false))
+
+	var gotMirroredHeadAdCid cid.Cid
+	var err error
+	require.Eventually(t, func() bool {
+		gotMirroredHeadAdCid, err = te.mirrorSyncer.GetHead(ctx)
+		if err != nil || cid.Undef.Equals(gotMirroredHeadAdCid) {
+			return false
+		}
+		// Check that head CID in mirror is the same as original head cid sicne ad chain must be
+		// identical.
+		_, err = te.syncMirrorAd(ctx, gotMirroredHeadAdCid)
+		return err == nil && originalHeadCid.Equals(gotMirroredHeadAdCid)
+	}, testEventualTimeout, testCheckInterval, "err: %v", err)
+
+	// Load head and assert it is mirrored correctly.
+	// Note that since head CIDs are equal and assertions from mirror actually sync data over
+	// graphsync, then it means the remaining ad chain must be the same since CIDs are implicitly
+	// verified against the content.
+	te.requireAdChainMirroredRecursively(t, ctx, originalHeadCid, gotMirroredHeadAdCid)
+}

--- a/mirror/options.go
+++ b/mirror/options.go
@@ -1,0 +1,188 @@
+package mirror
+
+import (
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine/chunker"
+	stischema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-datastore"
+	dssync "github.com/ipfs/go-datastore/sync"
+	hamt "github.com/ipld/go-ipld-adl-hamt"
+	"github.com/ipld/go-ipld-prime/schema"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/multiformats/go-multicodec"
+)
+
+type (
+	Option  func(*options) error
+	options struct {
+		h                           host.Host
+		ds                          datastore.Batching
+		ticker                      *time.Ticker
+		initAdRecurLimit            selector.RecursionLimit
+		entriesRecurLimit           selector.RecursionLimit
+		chunkerFunc                 chunker.NewChunkerFunc
+		chunkCacheCap               int
+		chunkCachePurge             bool
+		topic                       string
+		skipRemapOnEntriesTypeMatch bool
+		entriesRemapPrototype       schema.TypedPrototype
+		alwaysReSignAds             bool
+	}
+)
+
+// TODO: add options to restructure advertisements.
+//       nft.storage advertisement chain is a good usecase, where remapping entries to say HAMT
+//       probably won't make much difference. But combining ads to make a shorter chain will most
+//       likely improve end-to-end ingestion latency.
+
+func newOptions(o ...Option) (*options, error) {
+	opts := options{
+		ticker:            time.NewTicker(10 * time.Minute),
+		initAdRecurLimit:  selector.RecursionLimitNone(),
+		entriesRecurLimit: selector.RecursionLimitNone(),
+		chunkCacheCap:     1024,
+		chunkCachePurge:   false,
+		topic:             "/indexer/ingest/mainnet",
+	}
+	for _, apply := range o {
+		if err := apply(&opts); err != nil {
+			return nil, err
+		}
+	}
+	if opts.h == nil {
+		var err error
+		if opts.h, err = libp2p.New(); err != nil {
+			return nil, err
+		}
+	}
+	if opts.ds == nil {
+		opts.ds = dssync.MutexWrap(datastore.NewMapDatastore())
+	}
+	return &opts, nil
+}
+
+func (o *options) remapEntriesEnabled() bool {
+	// Use whether the chunker func is set or not as a flag to decide if entries should be remapped.
+	return o.chunkerFunc != nil
+}
+
+// WithHost specifies the libp2p host the mirror should be exposed on.
+// If unspecified a host with default options and random identity is used.
+func WithHost(h host.Host) Option {
+	return func(o *options) error {
+		o.h = h
+		return nil
+	}
+}
+
+// WithEntryChunkRemapper remaps the entries from the original provider into schema.EntryChunkPrototype
+// structure with the given chunk size.
+// If unset, the original structure is mirrored without change.
+//
+// See: WithSkipRemapOnEntriesTypeMatch, WithHamtRemapper.
+func WithEntryChunkRemapper(chunkSize int) Option {
+	return func(o *options) error {
+		o.entriesRemapPrototype = stischema.EntryChunkPrototype
+		o.chunkerFunc = chunker.NewChainChunkerFunc(chunkSize)
+		return nil
+	}
+}
+
+// WithHamtRemapper remaps the entries from the original provider into hamt.HashMapRootPrototype
+// structure with the given bit-width and bucket size.
+// If unset, the original structure is mirrored without change.
+//
+// See: WithSkipRemapOnEntriesTypeMatch, WithEntryChunkRemapper.
+func WithHamtRemapper(hashAlg multicodec.Code, bitwidth, bucketSize int) Option {
+	return func(o *options) error {
+		o.entriesRemapPrototype = hamt.HashMapRootPrototype
+		o.chunkerFunc = chunker.NewHamtChunkerFunc(hashAlg, bitwidth, bucketSize)
+		return nil
+	}
+}
+
+// WithSkipRemapOnEntriesTypeMatch specifies weather to skip remapping entries if the original
+// structure prototype matches the configured remap option.
+// Note that setting this option without setting a remap option has no effect.
+//
+// See: WithEntryChunkRemapper, WithHamtRemapper.
+func WithSkipRemapOnEntriesTypeMatch(s bool) Option {
+	return func(o *options) error {
+		o.skipRemapOnEntriesTypeMatch = s
+		return nil
+	}
+}
+
+// WithSyncInterval specifies the time interval at which the original provider is checked for new
+// advertisements.
+// If unset, the default time interval of 10 minutes is used.
+func WithSyncInterval(t *time.Ticker) Option {
+	return func(o *options) error {
+		o.ticker = t
+		return nil
+	}
+}
+
+// WithInitialAdRecursionLimit specifies the recursion limit for the initial sync if no previous
+// advertisements are mirrored by the mirror.
+// If unset, selector.RecursionLimitNone is used.
+func WithInitialAdRecursionLimit(l selector.RecursionLimit) Option {
+	return func(o *options) error {
+		o.initAdRecurLimit = l
+		return nil
+	}
+}
+
+// WithEntriesRecursionLimit specifies the recursion limit for syncing the advertisement entries.
+// If unset, selector.RecursionLimitNone is used.
+func WithEntriesRecursionLimit(l selector.RecursionLimit) Option {
+	return func(o *options) error {
+		o.entriesRecurLimit = l
+		return nil
+	}
+}
+
+// WithRemappedEntriesCacheCapacity sets the LRU cache capacity used to store the remapped
+// advertisement entries. The capacity refers to the number of complete entries DAGs cached. The
+// actual storage occupied by the cache depends on the shape of the DAGs.
+// See: chunker.CachedEntriesChunker.
+//
+// This option has no effect if no entries remapper option is set.
+// Defaults to 1024.
+func WithRemappedEntriesCacheCapacity(c int) Option {
+	return func(o *options) error {
+		o.chunkCacheCap = c
+		return nil
+	}
+}
+
+// WithPurgeCachedEntries specifies whether to delete any cached entries on start-up.
+// This option has no effect if no entries remapper option is set.
+func WithPurgeCachedEntries(b bool) Option {
+	return func(o *options) error {
+		o.chunkCachePurge = b
+		return nil
+	}
+}
+
+// WithTopicName specifies the topi name on which the mirrored advertisements are announced.
+func WithTopicName(t string) Option {
+	return func(o *options) error {
+		o.topic = t
+		return nil
+	}
+}
+
+// WithAlwaysReSignAds specifies whether every mirrored ad should be resigned by the mirror identity
+// regardless of weather the advertisement content is changed as a result of mirroring or not.
+// By default, advertisements are only re-signed if: 1) the link to previous advertisement is not
+// changed, and 2) link to entries is not changed.
+func WithAlwaysReSignAds(r bool) Option {
+	return func(o *options) error {
+		o.alwaysReSignAds = r
+		return nil
+	}
+}

--- a/mirror/selectors.go
+++ b/mirror/selectors.go
@@ -1,0 +1,35 @@
+package mirror
+
+import (
+	"github.com/filecoin-project/go-legs"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/traversal/selector"
+	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+)
+
+var selectors struct {
+	entriesWithLimit      func(limit selector.RecursionLimit) ipld.Node
+	adsWithRecursionLimit func(selector.RecursionLimit) ipld.Node
+	adsWithStopAt         func(selector.RecursionLimit, ipld.Link) ipld.Node
+}
+
+func init() {
+	ssb := builder.NewSelectorSpecBuilder(basicnode.Prototype.Any)
+	adSequenceBuilder := ssb.ExploreFields(
+		func(efsb builder.ExploreFieldsSpecBuilder) {
+			efsb.Insert("PreviousID", ssb.ExploreRecursiveEdge())
+		})
+	selectors.entriesWithLimit = func(limit selector.RecursionLimit) ipld.Node {
+		return ssb.ExploreRecursive(limit,
+			ssb.ExploreFields(func(efsb builder.ExploreFieldsSpecBuilder) {
+				efsb.Insert("Next", ssb.ExploreRecursiveEdge())
+			})).Node()
+	}
+	selectors.adsWithRecursionLimit = func(limit selector.RecursionLimit) ipld.Node {
+		return ssb.ExploreRecursive(limit, adSequenceBuilder).Node()
+	}
+	selectors.adsWithStopAt = func(limit selector.RecursionLimit, stop ipld.Link) ipld.Node {
+		return legs.ExploreRecursiveWithStopNode(limit, adSequenceBuilder.Node(), stop)
+	}
+}

--- a/mirror/store.go
+++ b/mirror/store.go
@@ -1,0 +1,138 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+
+	provider "github.com/filecoin-project/index-provider"
+	stischema "github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	hamt "github.com/ipld/go-ipld-adl-hamt"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/node/basicnode"
+	"github.com/ipld/go-ipld-prime/node/bindnode"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+var (
+	latestMirroredAdCidKey = datastore.NewKey("latest-mirrored-ad-cid")
+	latestOriginalAdCidKey = datastore.NewKey("latest-original-ad-cid")
+)
+
+func (m *Mirror) getLatestOriginalAdCid(ctx context.Context) (cid.Cid, error) {
+	v, err := m.ds.Get(ctx, latestOriginalAdCidKey)
+	if err == datastore.ErrNotFound {
+		return cid.Undef, nil
+	}
+	if err != nil {
+		return cid.Undef, err
+	}
+	_, c, err := cid.CidFromBytes(v)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return c, nil
+}
+
+func (m *Mirror) setLatestOriginalAdCid(ctx context.Context, c cid.Cid) error {
+	return m.ds.Put(ctx, latestOriginalAdCidKey, c.Bytes())
+}
+
+func (m *Mirror) getLatestMirroredAdCid(ctx context.Context) (cid.Cid, error) {
+	v, err := m.ds.Get(ctx, latestMirroredAdCidKey)
+	if err == datastore.ErrNotFound {
+		return cid.Undef, nil
+	}
+	if err != nil {
+		return cid.Undef, err
+	}
+	_, c, err := cid.CidFromBytes(v)
+	if err != nil {
+		return cid.Undef, err
+	}
+	return c, nil
+}
+
+func (m *Mirror) setLatestMirroredAdCid(ctx context.Context, c cid.Cid) error {
+	return m.ds.Put(ctx, latestMirroredAdCidKey, c.Bytes())
+}
+
+func (m *Mirror) loadAd(ctx context.Context, c cid.Cid) (*stischema.Advertisement, error) {
+	an, err := m.ls.Load(ipld.LinkContext{Ctx: ctx}, cidlink.Link{Cid: c}, stischema.AdvertisementPrototype)
+	if err != nil {
+		return nil, err
+	}
+	return stischema.UnwrapAdvertisement(an)
+}
+
+func (m *Mirror) loadEntries(ctx context.Context, l ipld.Link) (provider.MultihashIterator, error) {
+	// TODO figure out how to avoid loading the link twice. Right now it is not possible to unwrap
+	//      a node that is already loaded with Any prototype.
+	lctx := ipld.LinkContext{Ctx: ctx}
+	n, err := m.ls.Load(lctx, l, basicnode.Prototype.Any)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case isEntryChunkNode(n):
+		return provider.EntryChunkMultihashIterator(l, m.ls)
+	case isHamtNode(n):
+		n, err := m.ls.Load(lctx, l, hamt.HashMapRootPrototype)
+		if err != nil {
+			return nil, err
+		}
+		root := bindnode.Unwrap(n).(*hamt.HashMapRoot)
+		return provider.HamtMultihashIterator(root, m.ls), nil
+	default:
+		return nil, errors.New("unknown entries type")
+	}
+}
+
+func (m *Mirror) getEntriesPrototype(ctx context.Context, l ipld.Link) (schema.TypedPrototype, error) {
+	n, err := m.ls.Load(ipld.LinkContext{Ctx: ctx}, l, basicnode.Prototype.Any)
+	if err != nil {
+		return nil, err
+	}
+	switch {
+	case isEntryChunkNode(n):
+		return stischema.EntryChunkPrototype, nil
+	case isHamtNode(n):
+		return hamt.HashMapRootPrototype, nil
+	default:
+		return nil, errors.New("unknown entries type")
+	}
+}
+
+func isHamtNode(n ipld.Node) bool {
+	_, err := n.LookupByString("hamt")
+	return err == nil
+}
+
+func isEntryChunkNode(n ipld.Node) bool {
+	_, err := n.LookupByString("Entries")
+	return err == nil
+}
+
+func (m *Mirror) setMirroredEntriesLink(ctx context.Context, mirrored, original ipld.Link) error {
+	k := mirroredLinkDatastoreKey(original)
+	return m.ds.Put(ctx, k, mirrored.(cidlink.Link).Cid.Bytes())
+}
+
+func (m *Mirror) getOriginalEntriesLinkFromMirror(ctx context.Context, original ipld.Link) (ipld.Link, error) {
+	k := mirroredLinkDatastoreKey(original)
+	v, err := m.ds.Get(ctx, k)
+	if err != nil {
+		return nil, err
+	}
+	_, c, err := cid.CidFromBytes(v)
+	if err != nil {
+		return nil, err
+	}
+	return cidlink.Link{Cid: c}, nil
+}
+
+func mirroredLinkDatastoreKey(original ipld.Link) datastore.Key {
+	return datastore.KeyWithNamespaces([]string{"mirrored-entries-link", original.String()})
+}


### PR DESCRIPTION
Implement the ability to periodically check the advertisement chain
published by an index provider an mirror it with optional remapping of
the original entries in HAMT or entry chunk.

Host the original ad chain in the mirror such that the mirror can also
act as a CDN for the original ad chain.

Implement a mirror testing environment that asserts various
configuration permutations function as expected.

Implement utilities to extract `MultihashIterator` from links stored by
an IPLD link system regardless of the underlying entries type.