### PR TITLE
"Remove All" ad support

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -440,7 +440,7 @@ func (e *Engine) publishAdvForIndex(ctx context.Context, p peer.ID, addrs []mult
 
 	log := log.With("providerID", p)
 
-	if contextID != nil {
+	if len(contextID) != 0 {
 		log = log.With("contextID", base64.StdEncoding.EncodeToString(contextID))
 		c, err = e.getKeyCidMap(ctx, p, contextID)
 		if err != nil && err != datastore.ErrNotFound {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -378,7 +378,6 @@ func (e *Engine) NotifyPut(ctx context.Context, provider *peer.AddrInfo, context
 //
 // See: Engine.RegisterMultihashLister, Engine.Publish.
 func (e *Engine) NotifyRemove(ctx context.Context, provider peer.ID, contextID []byte) (cid.Cid, error) {
-	// TODO: add support for "delete all" for provider
 	if provider == "" {
 		provider = e.options.provider.ID
 	}

--- a/engine/engine_api_test.go
+++ b/engine/engine_api_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/filecoin-project/index-provider/engine/chunker"
@@ -45,6 +46,13 @@ func (e *Engine) ProviderAddrs() []string {
 // Datastore returns the engine's datastore, exposed for testing purposes only.
 func (e *Engine) Datastore() datastore.Datastore {
 	return e.ds
+}
+
+func UnmarshalProviderAndContext(t *testing.T, bytes []byte) *providerAndContext {
+	p := &providerAndContext{}
+	err := json.Unmarshal(bytes, p)
+	require.NoError(t, err)
+	return p
 }
 
 func Test_EmptyConfigSetsDefaults(t *testing.T) {

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -550,7 +550,7 @@ func TestEngine_IndexConsistencyTest(t *testing.T) {
 	// there should be no records left in the cidProvAndKey index for the "fish" fontext id
 	_, c, err = cid.CidFromBytes(cidBytes)
 	require.NoError(t, err)
-	pAndCBytes, err = ds.Get(ctx, datastore.NewKey("map/cidProvAndKey/"+c.String()))
+	_, err = ds.Get(ctx, datastore.NewKey("map/cidProvAndKey/"+c.String()))
 	require.Error(t, err, datastore.ErrNotFound)
 }
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -369,9 +369,9 @@ func TestEngine_NotifyPutThenNotifyRemoveAndRemoveAll(t *testing.T) {
 }
 
 func TestEngine_IndexConsistencyTest(t *testing.T) {
-	// This test verifies the index consistency after adding and removing advertised content.
-	// The main goal is to make sure that with added complexity, the index is cleaned up and remains consistent
-	// after put / remove / removeAll operations.
+	// This test verifies the index consistency after processign add, remove and remove all ads.
+	// The main goal is to make sure that with the current complexity, the index is cleaned up and remains consistent.
+
 	ctx := contextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -349,6 +349,20 @@ func TestEngine_NotifyPutThenNotifyRemove(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, gotLatestAfterRmAdCid, gotRemoveAdCid)
 	require.NotEqual(t, gotLatestAfterRmAdCid, gotLatestAdCid)
+
+	// Remove All
+	gotRemoveAllAdCid, err := subject.NotifyRemove(ctx, "", nil)
+	require.NoError(t, err)
+	require.NotEqual(t, gotRemoveAdCid, gotRemoveAllAdCid)
+
+	gotLatestAfterRmAllAdCid, _, err := subject.GetLatestAdv(ctx)
+	require.NoError(t, err)
+	require.Equal(t, gotRemoveAllAdCid, gotLatestAfterRmAllAdCid)
+	require.NotEqual(t, gotLatestAfterRmAdCid, gotLatestAfterRmAllAdCid)
+
+	gotLatestAfterRmAllAd, err := subject.GetAdv(ctx, gotLatestAfterRmAllAdCid)
+	require.NoError(t, err)
+	verifyAd(t, ctx, subject, createAd(t, []byte{}, subject.ProviderID().String(), nil, "bafkreehdwdcefgh4dqkjv67uzcmw7oje", true, gotRemoveAdCid.String()), gotLatestAfterRmAllAd)
 }
 
 func TestEngine_NotifyRemoveWithDefaultProvider(t *testing.T) {

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -98,7 +98,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// advertisement.  Only if the removal had no contextID would the
 			// indexer ask for entry chunks to remove.
 			// We don't care what exact provider to ask the chunks for, so taking the dirst one is good enough.
-			provider, err := peer.IDFromBytes(key.Providers[0])
+			provider, err := peer.IDFromBytes(key.Provider)
 			if err != nil {
 				return nil, err
 			}

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -97,7 +97,8 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// deletes all indexes for the contextID in the removal
 			// advertisement.  Only if the removal had no contextID would the
 			// indexer ask for entry chunks to remove.
-			provider, err := peer.IDFromBytes(key.Provider)
+			// We don't care what exact provider to ask the chunks for, so taking the dirst one is good enough.
+			provider, err := peer.IDFromBytes(key.Providers[0])
 			if err != nil {
 				return nil, err
 			}

--- a/engine/linksystem.go
+++ b/engine/linksystem.go
@@ -98,7 +98,7 @@ func (e *Engine) mkLinkSystem() ipld.LinkSystem {
 			// advertisement.  Only if the removal had no contextID would the
 			// indexer ask for entry chunks to remove.
 			// We don't care what exact provider to ask the chunks for, so taking the dirst one is good enough.
-			provider, err := peer.IDFromBytes(key.Provider)
+			provider, err := peer.Decode(key.Provider)
 			if err != nil {
 				return nil, err
 			}

--- a/interface.go
+++ b/interface.go
@@ -73,7 +73,7 @@ type Interface interface {
 	//
 	// If contextID is nil then a "Remove All" message will be created that will remove all previously advertised
 	// content at both index-provider and indexer sides. This message type should be used with caution as
-	// executing it would require full index scan.
+	// executing it will require full index scan.
 	//
 	// This function returns the ID of the advertisement published.
 	NotifyRemove(ctx context.Context, providerID peer.ID, contextID []byte) (cid.Cid, error)

--- a/interface.go
+++ b/interface.go
@@ -71,6 +71,10 @@ type Interface interface {
 	//
 	// If providerID is empty then the default configured provider will be assumed.
 	//
+	// If contextID is nil then a "Remove All" message will be created that will remove all previously advertised
+	// content at both index-provider and indexer sides. This message type should be used with caution as
+	// executing it would require full index scan.
+	//
 	// This function returns the ID of the advertisement published.
 	NotifyRemove(ctx context.Context, providerID peer.ID, contextID []byte) (cid.Cid, error)
 

--- a/interface.go
+++ b/interface.go
@@ -71,8 +71,7 @@ type Interface interface {
 	//
 	// If providerID is empty then the default configured provider will be assumed.
 	//
-	// If contextID is nil then a "Remove All" message will be created that will remove all previously advertised
-	// content at both index-provider and indexer sides. This message type should be used with caution as
+	// An empty or nil contextID removes all the content previously advertised by the given providerID. That should be used with caution as
 	// executing it will require full index scan.
 	//
 	// This function returns the ID of the advertisement published.


### PR DESCRIPTION
This PR adds a support for Remove All ad, that cleans up all previously advertised content for provider. A related PR will be created on the storetheindex side to react upon this message.