### PR TITLE
Fixed index keys so that they are compatible with the future Remove All support

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -578,7 +578,7 @@ func (e *Engine) keyToCidKey(provider peer.ID, contextID []byte) datastore.Key {
 	case e.provider.ID:
 		return datastore.NewKey(keyToCidMapPrefix + string(contextID))
 	default:
-		return datastore.NewKey(keyToCidMapPrefix + string(contextID) + "/" + provider.String())
+		return datastore.NewKey(keyToCidMapPrefix + provider.String() + "/" + string(contextID))
 	}
 }
 
@@ -595,7 +595,7 @@ func (e *Engine) keyToMetadataKey(provider peer.ID, contextID []byte) datastore.
 	case e.provider.ID:
 		return datastore.NewKey(keyToMetadataMapPrefix + string(contextID))
 	default:
-		return datastore.NewKey(keyToMetadataMapPrefix + string(contextID) + "/" + provider.String())
+		return datastore.NewKey(keyToMetadataMapPrefix + provider.String() + "/" + string(contextID))
 	}
 }
 


### PR DESCRIPTION
This PR fixes index keys so that they are compatible with the future Remove All support. This is required to be able to do range queries by provider for index clean up.