### PR TITLE
Added implementation for the IPFS index provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,22 @@ provider import car -l http://localhost:3102 -i <path-to-car-file>
 
 Both CARv1 and CARv2 formats are supported. Index is regenerated on the fly if one is not present.
 
+#### Exposing reframe server from provider (experimental)
+
+Provider can export a reframe server. [Reframe](https://github.com/ipfs/specs/blob/main/reframe/REFRAME_PROTOCOL.md) is a protocol 
+that allows IPFS nodes to advertise their contents to indexers alongside DHT. Reframe server is off by default. 
+To enable it, add the following configuration block to the provider config file.
+
+```
+{
+  ...
+  Reframe {
+    ListenMultiaddr: "/ip4/0.0.0.0/tcp/50617 (example)"
+  }
+  ...
+}
+```
+
 ### Embedding index provider integration
 
 The [root go module](go.mod) offers a set of reusable libraries that can be used to embed index

--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -14,7 +14,9 @@ import (
 	"github.com/filecoin-project/index-provider/cmd/provider/internal/config"
 	"github.com/filecoin-project/index-provider/engine"
 	"github.com/filecoin-project/index-provider/engine/policy"
+
 	adminserver "github.com/filecoin-project/index-provider/server/admin/http"
+	reframeserver "github.com/filecoin-project/index-provider/server/reframe/http"
 	"github.com/filecoin-project/index-provider/supplier"
 	leveldb "github.com/ipfs/go-ds-leveldb"
 	gsimpl "github.com/ipfs/go-graphsync/impl"
@@ -170,12 +172,13 @@ func daemonCommand(cctx *cli.Context) error {
 	}
 	log.Infow("admin server initialized", "address", cfg.AdminServer.ListenMultiaddr)
 
-	errChan := make(chan error, 1)
+	adminErrChan := make(chan error, 1)
 	fmt.Fprintf(cctx.App.ErrWriter, "Starting admin server on %s ...", cfg.AdminServer.ListenMultiaddr)
 	go func() {
-		errChan <- adminSvr.Start()
+		adminErrChan <- adminSvr.Start()
 	}()
 
+	reframeErrChan := make(chan error, 1)
 	// If there are bootstrap peers and bootstrapping is enabled, then try to
 	// connect to the minimum set of peers.
 	if len(cfg.Bootstrap.Peers) != 0 && cfg.Bootstrap.MinimumPeers != 0 {
@@ -194,12 +197,47 @@ func daemonCommand(cctx *cli.Context) error {
 		defer bootstrapper.Close()
 	}
 
+	// setting up reframe server
+	var reframeSrv *reframeserver.Server
+	if len(cfg.Reframe.ListenMultiaddr) != 0 {
+		reframeAddr, err := cfg.Reframe.ListenNetAddr()
+		if err != nil {
+			return err
+		}
+
+		reframeSrv, err = reframeserver.New(
+			cfg.Reframe.CidTtl,
+			cfg.Reframe.ChunkSize,
+			cfg.Reframe.SnapshotSize,
+			cfg.Reframe.ProviderID,
+			cfg.Reframe.Addrs,
+			eng,
+			ds,
+			reframeserver.WithListenAddr(reframeAddr),
+			reframeserver.WithReadTimeout(cfg.Reframe.ReadTimeout),
+			reframeserver.WithWriteTimeout(cfg.Reframe.WriteTimeout),
+		)
+
+		if err != nil {
+			return err
+		}
+		log.Infow("reframe server initialized", "address", cfg.Reframe.ListenMultiaddr)
+
+		fmt.Fprintf(cctx.App.ErrWriter, "Starting reframe server on %s ...", cfg.Reframe.ListenMultiaddr)
+		go func() {
+			reframeErrChan <- reframeSrv.Start()
+		}()
+	}
+
 	var finalErr error
 	// Keep process running.
 	select {
 	case <-cctx.Done():
-	case err = <-errChan:
-		log.Errorw("Failed to start server", "err", err)
+	case err = <-adminErrChan:
+		log.Errorw("Failed to start admin server", "err", err)
+		finalErr = ErrDaemonStart
+	case err = <-reframeErrChan:
+		log.Errorw("Failed to start reframe server", "err", err)
 		finalErr = ErrDaemonStart
 	}
 
@@ -232,6 +270,12 @@ func daemonCommand(cctx *cli.Context) error {
 	if err = adminSvr.Shutdown(shutdownCtx); err != nil {
 		log.Errorw("Error shutting down admin server: %s", err)
 		finalErr = ErrDaemonStop
+	}
+	if reframeSrv != nil {
+		if err = reframeSrv.Shutdown(shutdownCtx); err != nil {
+			log.Errorw("Error shutting down reframe server.", "err", err)
+			finalErr = ErrDaemonStop
+		}
 	}
 	log.Infow("node stopped")
 	return finalErr

--- a/cmd/provider/internal/config/config.go
+++ b/cmd/provider/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AdminServer    AdminServer
 	Bootstrap      Bootstrap
 	DirectAnnounce DirectAnnounce
+	Reframe        Reframe
 }
 
 const (
@@ -101,6 +102,7 @@ func Load(filePath string) (*Config, error) {
 		AdminServer:    NewAdminServer(),
 		ProviderServer: NewProviderServer(),
 		DirectAnnounce: NewDirectAnnounce(),
+		Reframe:        NewReframe(),
 	}
 
 	if err = json.NewDecoder(f).Decode(&cfg); err != nil {
@@ -156,4 +158,5 @@ func (c *Config) PopulateDefaults() {
 	c.Datastore.PopulateDefaults()
 	c.Ingest.PopulateDefaults()
 	c.ProviderServer.PopulateDefaults()
+	c.Reframe.PopulateDefaults()
 }

--- a/cmd/provider/internal/config/init.go
+++ b/cmd/provider/internal/config/init.go
@@ -26,6 +26,7 @@ func InitWithIdentity(identity Identity) (*Config, error) {
 		Ingest:         NewIngest(),
 		ProviderServer: NewProviderServer(),
 		AdminServer:    NewAdminServer(),
+		Reframe:        NewReframe(),
 	}, nil
 }
 

--- a/cmd/provider/internal/config/reframe.go
+++ b/cmd/provider/internal/config/reframe.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"time"
+
+	"github.com/multiformats/go-multiaddr"
+	manet "github.com/multiformats/go-multiaddr/net"
+)
+
+const (
+	defaultReframeReadTimeout  = time.Duration(10 * time.Minute)
+	defaultReframeWriteTimeout = time.Duration(10 * time.Minute)
+	defaultReframeCidTtl       = 24 * time.Hour
+	defaultReframeChunkSize    = 1_000
+	defaultReframeSnapshotSize = 10_000
+)
+
+// Reframe tracks the configuration of reframe serber. If specified, index provider will expose a reframe server that will
+// allow an IPFS node to advertise their CIDs through the delegated routing protocol.
+type Reframe struct {
+	ListenMultiaddr string
+	ReadTimeout     time.Duration
+	WriteTimeout    time.Duration
+	// CidTtl is a lifetime of a cid after which it is considered expired
+	CidTtl time.Duration
+	// ChunkSize is size of a chunk before it gets avertised to an indexer
+	ChunkSize int
+	// SnapshotSize is the maximum number of records in the Provide payload after which it is considered a snapshot.
+	// Snapshots don't have individual timestamps recorded into the datastore. Instead, timestamps are recorded as a binary blob after processing is done.
+	SnapshotSize int
+	// ProviderID is a Peer ID of the IPFS node that the reframe server is expecting advertisements from
+	ProviderID string
+	// Addrs is a list of multiaddresses of the IPFS node that the reframe server is expecting advertisements from
+	Addrs []string
+}
+
+// NewReframe instantiates a new Reframe config with default values.
+func NewReframe() Reframe {
+	return Reframe{
+		// we would like this functionality to be off by default
+		ProviderID:      "",
+		ListenMultiaddr: "",
+		ReadTimeout:     defaultReframeReadTimeout,
+		WriteTimeout:    defaultReframeWriteTimeout,
+		CidTtl:          defaultReframeCidTtl,
+		ChunkSize:       defaultReframeChunkSize,
+		SnapshotSize:    defaultReframeSnapshotSize,
+	}
+}
+
+// PopulateDefaults replaces zero-values in the config with default values.
+func (c *Reframe) PopulateDefaults() {
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = defaultReframeReadTimeout
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = defaultReframeWriteTimeout
+	}
+	if c.CidTtl == 0 {
+		c.CidTtl = defaultReframeCidTtl
+	}
+	if c.ChunkSize == 0 {
+		c.ChunkSize = defaultReframeChunkSize
+	}
+	if c.SnapshotSize == 0 {
+		c.SnapshotSize = defaultReframeSnapshotSize
+	}
+}
+
+func (as *Reframe) ListenNetAddr() (string, error) {
+	maddr, err := multiaddr.NewMultiaddr(as.ListenMultiaddr)
+	if err != nil {
+		return "", err
+	}
+
+	netAddr, err := manet.ToNetAddr(maddr)
+	if err != nil {
+		return "", err
+	}
+	return netAddr.String(), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/ipfs/go-cid v0.3.2
 	github.com/ipfs/go-datastore v0.6.0
+	github.com/ipfs/go-delegated-routing v0.6.0
 	github.com/ipfs/go-ds-leveldb v0.5.0
 	github.com/ipfs/go-graphsync v0.13.2
 	github.com/ipfs/go-ipfs-blockstore v1.2.0
@@ -90,12 +91,14 @@ require (
 	github.com/ipfs/go-ipld-cbor v0.0.6 // indirect
 	github.com/ipfs/go-ipld-format v0.4.0 // indirect
 	github.com/ipfs/go-ipld-legacy v0.1.1 // indirect
+	github.com/ipfs/go-ipns v0.3.0 // indirect
 	github.com/ipfs/go-log v1.0.5 // indirect
 	github.com/ipfs/go-merkledag v0.6.0 // indirect
 	github.com/ipfs/go-metrics-interface v0.0.1 // indirect
 	github.com/ipfs/go-peertaskqueue v0.7.1 // indirect
 	github.com/ipfs/go-unixfsnode v1.4.0 // indirect
 	github.com/ipfs/go-verifcid v0.0.2 // indirect
+	github.com/ipld/edelweiss v0.2.0 // indirect
 	github.com/jackpal/go-nat-pmp v1.0.2 // indirect
 	github.com/jbenet/go-temp-err-catcher v0.1.0 // indirect
 	github.com/jbenet/goprocess v0.1.4 // indirect
@@ -109,6 +112,7 @@ require (
 	github.com/libp2p/go-libp2p-asn-util v0.2.0 // indirect
 	github.com/libp2p/go-libp2p-core v0.20.1 // indirect
 	github.com/libp2p/go-libp2p-gostream v0.5.0 // indirect
+	github.com/libp2p/go-libp2p-record v0.2.0 // indirect
 	github.com/libp2p/go-msgio v0.2.0 // indirect
 	github.com/libp2p/go-nat v0.1.0 // indirect
 	github.com/libp2p/go-netroute v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,8 @@ github.com/ipfs/go-datastore v0.5.0/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh7
 github.com/ipfs/go-datastore v0.5.1/go.mod h1:9zhEApYMTl17C8YDp7JmU7sQZi2/wqiYh73hakZ90Bk=
 github.com/ipfs/go-datastore v0.6.0 h1:JKyz+Gvz1QEZw0LsX1IBn+JFCJQH4SJVFtM4uWU0Myk=
 github.com/ipfs/go-datastore v0.6.0/go.mod h1:rt5M3nNbSO/8q1t4LNkLyUwRs8HupMeN/8O4Vn9YAT8=
+github.com/ipfs/go-delegated-routing v0.6.0 h1:+M1siyTB2H4mHzEnbWjepQxlmKbapVWdbYLexSDODpg=
+github.com/ipfs/go-delegated-routing v0.6.0/go.mod h1:FJjhCChfcWK9z6OXo2jwKKJoxq1JlEWG7YTvwaA7UbI=
 github.com/ipfs/go-detect-race v0.0.1 h1:qX/xay2W3E4Q1U7d9lNs1sU9nvguX0a7319XbyQ6cOk=
 github.com/ipfs/go-detect-race v0.0.1/go.mod h1:8BNT7shDZPo99Q74BpGMK+4D8Mn4j46UU0LZ723meps=
 github.com/ipfs/go-ds-badger v0.0.2/go.mod h1:Y3QpeSFWQf6MopLTiZD+VT6IC1yZqaGmjvRcKeSGij8=
@@ -512,6 +514,8 @@ github.com/ipfs/go-ipld-format v0.4.0/go.mod h1:co/SdBE8h99968X0hViiw1MNlh6fvxxn
 github.com/ipfs/go-ipld-legacy v0.1.0/go.mod h1:86f5P/srAmh9GcIcWQR9lfFLZPrIyyXQeVlOWeeWEuI=
 github.com/ipfs/go-ipld-legacy v0.1.1 h1:BvD8PEuqwBHLTKqlGFTHSwrwFOMkVESEvwIYwR2cdcc=
 github.com/ipfs/go-ipld-legacy v0.1.1/go.mod h1:8AyKFCjgRPsQFf15ZQgDB8Din4DML/fOmKZkkFkrIEg=
+github.com/ipfs/go-ipns v0.3.0 h1:ai791nTgVo+zTuq2bLvEGmWP1M0A6kGTXUsgv/Yq67A=
+github.com/ipfs/go-ipns v0.3.0/go.mod h1:3cLT2rbvgPZGkHJoPO1YMJeh6LtkxopCkKFcio/wE24=
 github.com/ipfs/go-log v0.0.1/go.mod h1:kL1d2/hzSpI0thNYjiKfjanbVNU+IIGA/WnNESY9leM=
 github.com/ipfs/go-log v1.0.0/go.mod h1:JO7RzlMK6rA+CIxFMLOuB6Wf5b81GDiKElL7UPSIKjA=
 github.com/ipfs/go-log v1.0.1/go.mod h1:HuWlQttfN6FWNHRhlY5yMk/lW7evQC0HHGOxEwMRR8I=
@@ -547,6 +551,8 @@ github.com/ipfs/go-verifcid v0.0.2 h1:XPnUv0XmdH+ZIhLGKg6U2vaPaRDXb9urMyNVCE7uvT
 github.com/ipfs/go-verifcid v0.0.2/go.mod h1:40cD9x1y4OWnFXbLNJYRe7MpNvWlMn3LZAG5Wb4xnPU=
 github.com/ipfs/kubo v0.16.0 h1:goK1zdbHHTYVczj20BvAoA6PWiYvBdDgk8zDH+bKwUs=
 github.com/ipfs/kubo v0.16.0/go.mod h1:mkYGiXL+oi2TCkbUwaDSiOuqvLORuUfnDadIL6GWQIQ=
+github.com/ipld/edelweiss v0.2.0 h1:KfAZBP8eeJtrLxLhi7r3N0cBCo7JmwSRhOJp3WSpNjk=
+github.com/ipld/edelweiss v0.2.0/go.mod h1:FJAzJRCep4iI8FOFlRriN9n0b7OuX3T/S9++NpBDmA4=
 github.com/ipld/go-car/v2 v2.1.1/go.mod h1:+2Yvf0Z3wzkv7NeI69i8tuZ+ft7jyjPYIWZzeVNeFcI=
 github.com/ipld/go-car/v2 v2.4.1 h1:9S+FYbQzQJ/XzsdiOV13W5Iu/i+gUnr6csbSD9laFEg=
 github.com/ipld/go-car/v2 v2.4.1/go.mod h1:zjpRf0Jew9gHqSvjsKVyoq9OY9SWoEKdYCQUKVaaPT0=
@@ -749,6 +755,7 @@ github.com/libp2p/go-libp2p-quic-transport v0.16.0/go.mod h1:1BXjVMzr+w7EkPfiHkK
 github.com/libp2p/go-libp2p-quic-transport v0.17.0/go.mod h1:x4pw61P3/GRCcSLypcQJE/Q2+E9f4X+5aRcZLXf20LM=
 github.com/libp2p/go-libp2p-record v0.1.0/go.mod h1:ujNc8iuE5dlKWVy6wuL6dd58t0n7xI4hAIl8pE6wu5Q=
 github.com/libp2p/go-libp2p-record v0.2.0 h1:oiNUOCWno2BFuxt3my4i1frNrt7PerzB3queqa1NkQ0=
+github.com/libp2p/go-libp2p-record v0.2.0/go.mod h1:I+3zMkvvg5m2OcSdoL0KPljyJyvNDFGKX7QdlpYUcwk=
 github.com/libp2p/go-libp2p-resource-manager v0.2.1/go.mod h1:K+eCkiapf+ey/LADO4TaMpMTP9/Qde/uLlrnRqV4PLQ=
 github.com/libp2p/go-libp2p-secio v0.1.0/go.mod h1:tMJo2w7h3+wN4pgU2LSYeiKPrfqBgkOsdiKK77hE7c8=
 github.com/libp2p/go-libp2p-secio v0.2.0/go.mod h1:2JdZepB8J5V9mBp79BmwsaPQhRPNN2NrnB2lKQcdy6g=

--- a/reframe/chunker.go
+++ b/reframe/chunker.go
@@ -1,0 +1,113 @@
+package reframe
+
+import (
+	"context"
+	"crypto/sha256"
+	"math/rand"
+	"sort"
+
+	"github.com/ipfs/go-cid"
+)
+
+type chunker struct {
+	chunkByContextId map[string]*cidsChunk
+	chunkByCid       map[cid.Cid]*cidsChunk
+	currentChunk     *cidsChunk
+	chunkSizeFunc    func() int
+	nonceGen         func() []byte
+}
+
+type cidsChunk struct {
+	ContextID []byte
+	Cids      map[cid.Cid]struct{}
+	Removed   bool
+}
+
+func defaultNonceGen() []byte {
+	nonce := make([]byte, 8)
+	rand.Read(nonce)
+	return nonce
+}
+
+func newChunker(chunkSizeFunc func() int, nonceGenFunc func() []byte) *chunker {
+	if nonceGenFunc == nil {
+		nonceGenFunc = defaultNonceGen
+	}
+	ch := &chunker{
+		chunkByContextId: make(map[string]*cidsChunk),
+		chunkByCid:       make(map[cid.Cid]*cidsChunk),
+		chunkSizeFunc:    chunkSizeFunc,
+		nonceGen:         nonceGenFunc,
+	}
+	ch.currentChunk = ch.newCidsChunk()
+	return ch
+}
+
+func (ch *chunker) getChunkByContextID(ctxID string) *cidsChunk {
+	if ctxID == contextIDToStr(ch.currentChunk.ContextID) {
+		return ch.currentChunk
+	}
+	return ch.chunkByContextId[ctxID]
+}
+
+func (ch *chunker) getChunkByCID(c cid.Cid) *cidsChunk {
+	return ch.chunkByCid[c]
+}
+
+func (ch *chunker) addChunk(chunk *cidsChunk) {
+	ch.chunkByContextId[contextIDToStr(chunk.ContextID)] = chunk
+	for k := range chunk.Cids {
+		ch.chunkByCid[k] = chunk
+	}
+}
+
+func (ch *chunker) removeChunk(chunk *cidsChunk) {
+	ctxIDStr := contextIDToStr(chunk.ContextID)
+	delete(ch.chunkByContextId, ctxIDStr)
+	for c := range chunk.Cids {
+		delete(ch.chunkByCid, c)
+	}
+}
+
+func (ch *chunker) newCidsChunk() *cidsChunk {
+	return &cidsChunk{Cids: make(map[cid.Cid]struct{}, ch.chunkSizeFunc()), Removed: false}
+}
+
+func (ch *chunker) addCidToCurrentChunk(ctx context.Context, c cid.Cid, chunkFullFunc func(*cidsChunk) error) error {
+	// if the cid is already in the chunk - do nothing
+	if _, ok := ch.currentChunk.Cids[c]; ok {
+		return nil
+	}
+
+	// if the current chunk is full - publish it and create a new one
+	if len(ch.currentChunk.Cids) >= ch.chunkSizeFunc() {
+		ch.currentChunk.ContextID = ch.generateContextID(ch.currentChunk.Cids)
+		err := chunkFullFunc(ch.currentChunk)
+		if err != nil {
+			return err
+		}
+
+		ch.currentChunk = ch.newCidsChunk()
+	}
+
+	ch.currentChunk.Cids[c] = struct{}{}
+
+	return nil
+}
+
+func (ch *chunker) generateContextID(cidsMap map[cid.Cid]struct{}) []byte {
+	cids := make([]string, len(cidsMap))
+	i := 0
+	for k := range cidsMap {
+		cids[i] = k.String()
+		i++
+	}
+	sort.Strings(cids)
+
+	hasher := sha256.New()
+	for _, c := range cids {
+		hasher.Write([]byte(c))
+	}
+	hasher.Write(ch.nonceGen())
+	return hasher.Sum(nil)
+}

--- a/reframe/cid_queue.go
+++ b/reframe/cid_queue.go
@@ -1,0 +1,57 @@
+package reframe
+
+import (
+	"container/list"
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+type cidQueue struct {
+	listNodeByCid map[cid.Cid]*list.Element
+	nodesLl       *list.List
+}
+
+type cidNode struct {
+	Timestamp time.Time
+	C         cid.Cid
+}
+
+func newCidQueue() *cidQueue {
+	return &cidQueue{
+		listNodeByCid: make(map[cid.Cid]*list.Element),
+		nodesLl:       list.New(),
+	}
+}
+
+func (cq *cidQueue) recordCidNode(node *cidNode) *list.Element {
+	if listElem, ok := cq.listNodeByCid[node.C]; ok {
+		listElem.Value.(*cidNode).Timestamp = node.Timestamp
+		cq.nodesLl.MoveToFront(listElem)
+		return listElem
+	} else {
+		listElem := cq.nodesLl.PushFront(node)
+		cq.listNodeByCid[node.C] = listElem
+		return listElem
+	}
+}
+
+func (cq *cidQueue) removeCidNode(c cid.Cid) {
+	if listNode, ok := cq.listNodeByCid[c]; ok {
+		cq.nodesLl.Remove(listNode)
+		delete(cq.listNodeByCid, c)
+	}
+}
+
+func (cq *cidQueue) getNodeByCid(c cid.Cid) *list.Element {
+	return cq.listNodeByCid[c]
+}
+
+func (cq *cidQueue) getTimestampsSnapshot() []*cidNode {
+	timestamps := make([]*cidNode, 0, len(cq.listNodeByCid))
+	for _, node := range cq.listNodeByCid {
+		cNode := node.Value.(*cidNode)
+		timestamps = append(timestamps, cNode)
+	}
+	return timestamps
+}

--- a/reframe/ds_wrapper.go
+++ b/reframe/ds_wrapper.go
@@ -1,0 +1,214 @@
+package reframe
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/gob"
+	"fmt"
+	"sort"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	dsq "github.com/ipfs/go-datastore/query"
+)
+
+const (
+	chunkByContextIdIndexPrefix = "ccid/"
+	timestampByCidIndexPrefix   = "tc/"
+	timestampsSnapshotIndexKey  = "ts"
+)
+
+// dsWrapper encapsulates all functionality related top the datastore
+type dsWrapper struct {
+	ds datastore.Datastore
+}
+
+// initialiseFromTheDatastore initialises in-memory data structures on first start
+func (d *dsWrapper) initialiseFromTheDatastore(ctx context.Context, cidImporter func(n *cidNode), chunkImporter func(c *cidsChunk)) error {
+	start := time.Now()
+	// reading timestamps snapshot from the datastore
+	snapshot, err := d.ds.Get(ctx, datastore.NewKey(timestampsSnapshotIndexKey))
+	if err != nil && err != datastore.ErrNotFound {
+		return fmt.Errorf("error reading timestamps snapshot from the datastore: %w", err)
+	}
+
+	var cidNodes []*cidNode
+	if snapshot != nil {
+		cidNodes, err = parseSnapshot(snapshot)
+		if err != nil {
+			return fmt.Errorf("error parsing timestamps snapshot: %w", err)
+		}
+	}
+
+	// reading timestamp by cid index from the datastore, sorting the slice by the timestamp and providing it into in memory indexes
+	q := dsq.Query{Prefix: timestampByCidIndexPrefix}
+	tcResults, err := d.ds.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("error reading timestamp by cid index from the datastore: %w", err)
+	}
+	defer tcResults.Close()
+	for r := range tcResults.Next() {
+		if r.Error != nil {
+			return fmt.Errorf("error fetching datastore record: %w", r.Error)
+		}
+
+		timestamp := bytesToInt64(r.Value)
+		cs := r.Key[len(timestampByCidIndexPrefix)+1:]
+		c, err := cid.Parse(cs)
+		if err != nil {
+			return fmt.Errorf("error parsing cid datastore record: %w", err)
+		}
+
+		cidNodes = append(cidNodes, &cidNode{Timestamp: time.UnixMilli(timestamp), C: c})
+	}
+
+	sort.SliceStable(cidNodes, func(i, j int) bool {
+		return cidNodes[i].Timestamp.Before(cidNodes[j].Timestamp)
+	})
+
+	for i := range cidNodes {
+		n := cidNodes[i]
+		cidImporter(n)
+	}
+
+	log.Infof("Loaded up all CIDs from the datastore in %v", time.Since(start))
+
+	start = time.Now()
+	// reading all cid chunks from the datastore and adding them up to the in-memory indexes
+	q = dsq.Query{Prefix: chunkByContextIdIndexPrefix}
+	ccResults, err := d.ds.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("error reading from the datastore: %w", err)
+	}
+	defer ccResults.Close()
+
+	for r := range ccResults.Next() {
+		if r.Error != nil {
+			return fmt.Errorf("error fetching datastore record: %w", r.Error)
+		}
+
+		chunk, err := deserialiseChunk(r.Value)
+		if err != nil {
+			return fmt.Errorf("error deserialising record from the datastore: %w", err)
+		}
+		// not importing removed chunks. They can be lazy loaded when needed.
+		if chunk.Removed {
+			continue
+		}
+		chunkImporter(chunk)
+	}
+
+	log.Infof("Loaded up all chunks from the datastore in %v", time.Since(start))
+
+	return nil
+}
+
+func parseSnapshot(snapshot []byte) ([]*cidNode, error) {
+	timestamps := make([]*cidNode, 0)
+	decoder := gob.NewDecoder(bytes.NewBuffer(snapshot))
+	err := decoder.Decode(&timestamps)
+	if err != nil {
+		return nil, err
+	}
+	return timestamps, nil
+}
+
+func (dsw *dsWrapper) hasSanpshot(ctx context.Context) (bool, error) {
+	return dsw.ds.Has(ctx, datastore.NewKey(timestampsSnapshotIndexKey))
+}
+
+func (dsw *dsWrapper) hasCidTimestamp(ctx context.Context, c cid.Cid) (bool, error) {
+	return dsw.ds.Has(ctx, timestampByCidKey(c))
+}
+
+func (dsw *dsWrapper) recordTimestampsSnapshot(ctx context.Context, timestamps []*cidNode, cleanUpTimestamps bool) error {
+	b := bytes.Buffer{}
+	e := gob.NewEncoder(&b)
+	err := e.Encode(timestamps)
+	if err != nil {
+		return err
+	}
+
+	err = dsw.ds.Put(ctx, datastore.NewKey(timestampsSnapshotIndexKey), b.Bytes())
+	if !cleanUpTimestamps {
+		return err
+	}
+
+	q := dsq.Query{Prefix: timestampByCidIndexPrefix, KeysOnly: true}
+	tcResults, err := dsw.ds.Query(ctx, q)
+	if err != nil {
+		return fmt.Errorf("error reading timestamp by cid index from the datastore: %w", err)
+	}
+	defer tcResults.Close()
+	for r := range tcResults.Next() {
+		err = dsw.ds.Delete(ctx, datastore.NewKey(r.Key))
+		if err != nil {
+			log.Warnf("Error cleaning up timestamp by cid index from datastore: %w. Continuing.", err)
+		}
+	}
+	return nil
+}
+
+func (dsw *dsWrapper) recordCidTimestamp(ctx context.Context, c cid.Cid, t time.Time) error {
+	return dsw.ds.Put(ctx, timestampByCidKey(c), int64ToBytes(t.UnixMilli()))
+}
+
+func (dsw *dsWrapper) deleteCidTimestamp(ctx context.Context, c cid.Cid) error {
+	return dsw.ds.Delete(ctx, timestampByCidKey(c))
+}
+
+func (dsw *dsWrapper) getCidTimestamp(ctx context.Context, c cid.Cid) (time.Time, error) {
+	timeBytes, err := dsw.ds.Get(ctx, timestampByCidKey(c))
+	if err != nil {
+		return time.Now(), err
+	}
+	return time.UnixMilli(bytesToInt64(timeBytes)), nil
+}
+
+func (dsw *dsWrapper) recordChunkByContextID(ctx context.Context, chunk *cidsChunk) error {
+	b := bytes.Buffer{}
+	e := gob.NewEncoder(&b)
+	err := e.Encode(chunk)
+	if err != nil {
+		return err
+	}
+	return dsw.ds.Put(ctx, chunkByContextIDKey(chunk.ContextID), b.Bytes())
+}
+
+func (dsw *dsWrapper) getChunkByContextID(ctx context.Context, contextID []byte) (*cidsChunk, error) {
+	chunkBytes, err := dsw.ds.Get(ctx, chunkByContextIDKey(contextID))
+	if err != nil {
+		return nil, err
+	}
+	return deserialiseChunk(chunkBytes)
+}
+
+func deserialiseChunk(chunkBytes []byte) (*cidsChunk, error) {
+	chunk := &cidsChunk{Cids: make(map[cid.Cid]struct{})}
+	decoder := gob.NewDecoder(bytes.NewBuffer(chunkBytes))
+	err := decoder.Decode(chunk)
+	if err != nil {
+		return nil, err
+	}
+	return chunk, nil
+}
+
+func timestampByCidKey(c cid.Cid) datastore.Key {
+	return datastore.NewKey(timestampByCidIndexPrefix + c.String())
+}
+
+func chunkByContextIDKey(contextID []byte) datastore.Key {
+	return datastore.NewKey(chunkByContextIdIndexPrefix + contextIDToStr(contextID))
+}
+
+func int64ToBytes(i int64) []byte {
+	b := make([]byte, 8)
+	binary.LittleEndian.PutUint64(b, uint64(i))
+	return b
+}
+
+func bytesToInt64(b []byte) int64 {
+	return int64(binary.LittleEndian.Uint64(b))
+}

--- a/reframe/listener.go
+++ b/reframe/listener.go
@@ -1,0 +1,515 @@
+package reframe
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"sort"
+	"sync"
+	"time"
+
+	provider "github.com/filecoin-project/index-provider"
+	"github.com/filecoin-project/index-provider/metadata"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-datastore/namespace"
+	"github.com/libp2p/go-libp2p/core/peer"
+
+	"github.com/ipfs/go-delegated-routing/client"
+	logging "github.com/ipfs/go-log/v2"
+
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multihash"
+)
+
+var log = logging.Logger("reframe/listener")
+var bitswapMetadata = metadata.New(metadata.Bitswap{})
+
+const (
+	reframeDSName               = "reframe"
+	statsPrintFrequency         = time.Minute
+	retryWithBackoffInterval    = 5 * time.Second
+	retryWithBackoffMaxAttempts = 3
+)
+
+type ReframeListener struct {
+	dsWrapper    *dsWrapper
+	engine       provider.Interface
+	cidTtl       time.Duration
+	chunkSize    int
+	snapshotSize int
+	// ReframeListener maintains in memory indexes for fast key value lookups
+	// as well as a rolling double-linked list of CIDs ordered by their timestamp.
+	// Once a CID gets advertised, the respective linked list node gets moved to the
+	// beginning of the list. To identify CIDs to expire, ReframeListener would walk the list tail to head.
+	// TODO: offload cid chunks to disk to save RAM
+	chunker                *chunker
+	cidQueue               *cidQueue
+	lastSeenProviderInfo   *peer.AddrInfo
+	configuredProviderInfo *peer.AddrInfo
+	stats                  *statsReporter
+	lock                   sync.Mutex
+}
+
+type ReframeMultihashLister struct {
+	CidFetcher func(contextID []byte) (map[cid.Cid]struct{}, error)
+}
+
+func (lister *ReframeMultihashLister) MultihashLister(ctx context.Context, p peer.ID, contextID []byte) (provider.MultihashIterator, error) {
+	contextIdStr := contextIDToStr(contextID)
+	cids, err := lister.CidFetcher(contextID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	mhs := make([]multihash.Multihash, 0, len(cids))
+	for c := range cids {
+		mhs = append(mhs, c.Hash())
+	}
+
+	sort.SliceStable(mhs, func(i, j int) bool {
+		return mhs[i].String() < mhs[j].String()
+	})
+
+	log.Infow("Returning a chunk from MultihashLister", "contextId", contextIdStr, "size", len(mhs))
+
+	return provider.SliceMultihashIterator(mhs), nil
+}
+
+// NewReframeListenerWithNonceGen creates a reframe listener and initialises its state from the provided datastore.
+func New(ctx context.Context, engine provider.Interface,
+	cidTtl time.Duration,
+	chunkSize int,
+	snapshotSize int,
+	providerId string,
+	addresses []string,
+	ds datastore.Datastore,
+	nonceGen func() []byte) (*ReframeListener, error) {
+
+	listener := &ReframeListener{
+		engine:       engine,
+		cidTtl:       cidTtl,
+		chunkSize:    chunkSize,
+		snapshotSize: snapshotSize,
+		dsWrapper: &dsWrapper{
+			ds: namespace.Wrap(ds, datastore.NewKey(reframeDSName))},
+		lastSeenProviderInfo:   &peer.AddrInfo{},
+		configuredProviderInfo: nil,
+		chunker:                newChunker(func() int { return chunkSize }, nonceGen),
+		cidQueue:               newCidQueue(),
+	}
+
+	listener.stats = newStatsReporter(
+		func() int { return len(listener.cidQueue.listNodeByCid) },
+		func() int { return len(listener.chunker.chunkByContextId) },
+		func() int { return len(listener.chunker.currentChunk.Cids) },
+	)
+
+	lister := &ReframeMultihashLister{
+		CidFetcher: func(contextID []byte) (map[cid.Cid]struct{}, error) {
+			ctxIdStr := contextIDToStr(contextID)
+			chunk := listener.chunker.getChunkByContextID(ctxIdStr)
+			if chunk != nil {
+				return chunk.Cids, nil
+			}
+			// if chunk doesn't exist in memory - it might have been evicted during deletion
+			chunk, err := listener.dsWrapper.getChunkByContextID(ctx, contextID)
+			if err == nil {
+				listener.stats.incChunkCacheMisses()
+				return chunk.Cids, nil
+			}
+			listener.stats.incChunksNotFound()
+			return nil, fmt.Errorf("multihasLister couldn't find a chunk for contextID %s", contextIDToStr(contextID))
+		},
+	}
+	engine.RegisterMultihashLister(lister.MultihashLister)
+
+	log.Info("Initialising from the datastore")
+	err := listener.dsWrapper.initialiseFromTheDatastore(ctx, func(n *cidNode) {
+		listener.cidQueue.recordCidNode(n)
+	}, func(chunk *cidsChunk) {
+		listener.chunker.addChunk(chunk)
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// recording merged snapshot and cleaning up individual mappings from the datastore
+	if len(listener.cidQueue.listNodeByCid) > 0 {
+		listener.dsWrapper.recordTimestampsSnapshot(ctx, listener.cidQueue.getTimestampsSnapshot(), true)
+	}
+
+	log.Infof("Loaded up %d cids and %d chunks from the datastore.", len(listener.cidQueue.listNodeByCid), len(listener.chunker.chunkByContextId))
+
+	if providerId != "" {
+		p, err := peer.Decode(providerId)
+		if err != nil {
+			return nil, err
+		}
+
+		maddrs := make([]multiaddr.Multiaddr, len(addresses))
+		for i, s := range addresses {
+			a, err := multiaddr.NewMultiaddr(s)
+			if err != nil {
+				return nil, err
+			}
+			maddrs[i] = a
+		}
+
+		listener.configuredProviderInfo = &peer.AddrInfo{
+			ID:    p,
+			Addrs: maddrs,
+		}
+	}
+
+	listener.stats.start()
+
+	return listener, nil
+}
+
+func (listener *ReframeListener) Shutdown() {
+	listener.stats.shutdown()
+}
+
+func (listener *ReframeListener) GetIPNS(ctx context.Context, id []byte) (<-chan client.GetIPNSAsyncResult, error) {
+	log.Warn("Received unsupported getIPNS request")
+	ch := make(chan client.GetIPNSAsyncResult, 1)
+	go func() {
+		// Not implemented
+		ch <- client.GetIPNSAsyncResult{Record: nil}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (listener *ReframeListener) PutIPNS(ctx context.Context, id []byte, record []byte) (<-chan client.PutIPNSAsyncResult, error) {
+	log.Warn("Received unsupported putIPNS request")
+	ch := make(chan client.PutIPNSAsyncResult, 1)
+	go func() {
+		// Not implemented
+		ch <- client.PutIPNSAsyncResult{}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (listener *ReframeListener) FindProviders(ctx context.Context, key cid.Cid) (<-chan client.FindProvidersAsyncResult, error) {
+	log.Warn("Received unsupported findProviders request")
+	ch := make(chan client.FindProvidersAsyncResult, 1)
+	go func() {
+		// Not implemented
+		ch <- client.FindProvidersAsyncResult{AddrInfo: nil}
+		close(ch)
+	}()
+	return ch, nil
+}
+
+func (listener *ReframeListener) Provide(ctx context.Context, pr *client.ProvideRequest) (<-chan client.ProvideAsyncResult, error) {
+	ch := make(chan client.ProvideAsyncResult, 1)
+	log.Infof("Received Provide request with %d cids.", len(pr.Key))
+	listener.stats.incReframeCallsReceived()
+
+	go func() {
+		startTime := time.Now()
+		printFrequency := 10_000
+		listener.lock.Lock()
+		defer func() {
+			listener.stats.incReframeCallsProcessed()
+			log.Infow("Finished processing Provide request.", "time", time.Since(startTime), "len", len(pr.Key))
+			listener.lock.Unlock()
+			close(ch)
+		}()
+		// shadowing the calling function's context so that cancellation of it doesn't affect processing
+		ctx := context.Background()
+		// Using mutex to prevent concurrent Provide requests
+
+		if listener.configuredProviderInfo != nil && listener.configuredProviderInfo.ID != pr.Provider.Peer.ID {
+			log.Warnw("Skipping Provide request as its provider is different from the configured one.", "configured", listener.configuredProviderInfo.ID, "received", pr.Provider.Peer.ID)
+			ch <- client.ProvideAsyncResult{Err: fmt.Errorf("provider %s isn't allowed", pr.Provider.Peer.ID)}
+			return
+		}
+
+		if len(listener.lastSeenProviderInfo.ID) > 0 && listener.lastSeenProviderInfo.ID != pr.Provider.Peer.ID {
+			log.Warnw("Skipping Provide request as its provider is different from the last seen one.", "lastSeen", listener.lastSeenProviderInfo.ID, "received", pr.Provider.Peer.ID)
+			ch <- client.ProvideAsyncResult{Err: fmt.Errorf("provider %s isn't allowed", pr.Provider.Peer.ID)}
+			return
+		}
+
+		listener.lastSeenProviderInfo.ID = pr.Provider.Peer.ID
+		listener.lastSeenProviderInfo.Addrs = pr.Provider.Peer.Addrs
+
+		timestamp := time.Now()
+		for i, c := range pr.Key {
+
+			// persisting timestamp only if this is not a snapshot
+			if len(pr.Key) < listener.snapshotSize {
+				err := listener.dsWrapper.recordCidTimestamp(ctx, c, timestamp)
+				if err != nil {
+					log.Errorw("Error persisting timestamp. Continuing.", "cid", c, "err", err)
+					continue
+				}
+			}
+
+			listElem := listener.cidQueue.getNodeByCid(c)
+			if listElem == nil {
+				listener.cidQueue.recordCidNode(&cidNode{
+					C:         c,
+					Timestamp: timestamp,
+				})
+				err := listener.chunker.addCidToCurrentChunk(ctx, c, func(cc *cidsChunk) error {
+					return listener.notifyPutAndPersist(ctx, cc)
+				})
+				if err != nil {
+					log.Errorw("Error adding a cid to the current chunk. Continuing.", "cid", c, "err", err)
+					listener.cidQueue.removeCidNode(c)
+					continue
+				}
+			} else {
+				node := listElem.Value.(*cidNode)
+				node.Timestamp = timestamp
+				listener.cidQueue.recordCidNode(node)
+				// if no existing chunk has been found for the cid - adding it to the current one
+				// This can happen in the following cases:
+				//     * when currentChunk disappears between restarts as it doesn't get persisted until it's advertised
+				//     * when the same cid comes multiple times within the lifespan of the same chunk
+				//	   * after a error to generate a replacement chunk
+				err := listener.chunker.addCidToCurrentChunk(ctx, c, func(cc *cidsChunk) error {
+					return listener.notifyPutAndPersist(ctx, cc)
+				})
+				if err != nil {
+					log.Errorw("Error adding a cid to the current chunk. Continuing.", "cid", c, "err", err)
+					continue
+				}
+				listener.stats.incExistingCidsProcessed()
+			}
+
+			listener.stats.incCidsProcessed()
+			// Doing some logging for larger requests
+			if i != 0 && i%printFrequency == 0 {
+				log.Infof("Processed %d out of %d CIDs. startTime=%v", i, len(pr.Key), startTime)
+			}
+		}
+		err := listener.removeExpiredCids(ctx)
+		if err != nil {
+			log.Warnw("Error removing expired cids.", "err", err)
+		}
+
+		// if that was a snapshot - persisting timestamps as binary blob
+		if len(pr.Key) >= listener.snapshotSize {
+			listener.dsWrapper.recordTimestampsSnapshot(ctx, listener.cidQueue.getTimestampsSnapshot(), false)
+		}
+
+		response := client.ProvideAsyncResult{AdvisoryTTL: time.Duration(listener.cidTtl), Err: nil}
+		ch <- response
+	}()
+	return ch, nil
+}
+
+func (listener *ReframeListener) deleteCidFromDatastoreAndIndexes(ctx context.Context, c cid.Cid) {
+	err := listener.dsWrapper.deleteCidTimestamp(ctx, c)
+	if err != nil {
+		log.Warnw("Error cleaning up timestamp by cid index. Continuing.", "err", err)
+	}
+
+	listener.cidQueue.removeCidNode(c)
+}
+
+// Revise logic here
+func (listener *ReframeListener) removeExpiredCids(ctx context.Context) error {
+	lastElem := listener.cidQueue.nodesLl.Back()
+	currentTime := time.Now()
+	chunksToRemove := make(map[string]*cidsChunk)
+	cidsToRemove := make(map[cid.Cid]struct{})
+	printFrequency := 100
+	var cidsRemoved, chunksRemoved, chunksReplaced int
+	// find expired cids and their respective chunks
+	for {
+		if lastElem == nil {
+			break
+		}
+		lastNode := lastElem.Value.(*cidNode)
+
+		if currentTime.Sub(lastNode.Timestamp) <= listener.cidTtl {
+			break
+		}
+
+		chunk := listener.chunker.getChunkByCID(lastNode.C)
+		lastElem = lastElem.Prev()
+		if chunk != nil {
+			cidsToRemove[lastNode.C] = struct{}{}
+			ctxIdStr := contextIDToStr(chunk.ContextID)
+			chunksToRemove[ctxIdStr] = chunk
+		} else {
+			log.Warnf("No chunk found for expired cid=%s. Cleaning it up from indexes and datastore.", lastNode.C)
+			listener.deleteCidFromDatastoreAndIndexes(ctx, lastNode.C)
+		}
+	}
+
+	// remove old chunks and generate new chunks less the expired cids
+	counter := 0
+	for _, chunkToRemove := range chunksToRemove {
+		counter++
+		oldCtxIdStr := contextIDToStr(chunkToRemove.ContextID)
+
+		// removing the expired chunk first. If that fails - don't update indexs / datastore so that we can retry deletion
+		// on the next iteration
+		err := listener.notifyRemoveAndPersist(ctx, chunkToRemove)
+		if err != nil {
+			log.Warnw("Error removing a chunk. Continuing.", "contextID", oldCtxIdStr, "err", err)
+			for c := range chunkToRemove.Cids {
+				delete(cidsToRemove, c)
+			}
+			continue
+		} else {
+			chunksRemoved++
+		}
+
+		newChunk := listener.chunker.newCidsChunk()
+
+		for c := range chunkToRemove.Cids {
+			// if cid hasn't expired - adding it to the replacement chunk
+			if _, ok := cidsToRemove[c]; !ok {
+				newChunk.Cids[c] = struct{}{}
+				continue
+			}
+
+			// cleaning up the expired cid
+			listener.deleteCidFromDatastoreAndIndexes(ctx, c)
+			delete(cidsToRemove, c)
+			listener.stats.incCidsExpired()
+			cidsRemoved++
+		}
+		// only generating a new chunk if it has some cids left in it
+		if len(newChunk.Cids) > 0 {
+			newChunk.ContextID = listener.chunker.generateContextID(newChunk.Cids)
+			newCtxIdStr := contextIDToStr(newChunk.ContextID)
+			err = listener.notifyPutAndPersist(ctx, newChunk)
+			if err != nil {
+				log.Warnw("Error creating replacement chunk. Continuing.", "contextID", newCtxIdStr, "err", err)
+				// it's ok to continue - remaining CIDs are going to be picked up on the next snapshot
+				continue
+			}
+			chunksReplaced++
+		} else {
+			log.Infof("No CIDs left to generate a replacement chunk for %s.", contextIDToStr(chunkToRemove.ContextID))
+		}
+
+		if counter != 0 && counter%printFrequency == 0 {
+			log.Infof("Cleaning up chunk %d out of %d.", counter, len(chunksToRemove))
+		}
+	}
+
+	// we might have still some expired cids left, that didn't have any chunk associated to them
+	for c := range cidsToRemove {
+		// cleaning up the expired cid
+		listener.deleteCidFromDatastoreAndIndexes(ctx, c)
+	}
+
+	log.Infow("Finished cleaning up.", "cidsExpired", cidsRemoved, "chunksExpired", chunksRemoved, "chunksReplaced", chunksReplaced)
+
+	return nil
+}
+
+func (listener *ReframeListener) notifyRemoveAndPersist(ctx context.Context, chunk *cidsChunk) error {
+	ctxIdStr := contextIDToStr(chunk.ContextID)
+	log.Infof("Notifying Remove for chunk=%s", ctxIdStr)
+
+	// notifying the indexer
+	err := RetryWithBackoff(func() error {
+		_, e := listener.engine.NotifyRemove(ctx, listener.provider(), chunk.ContextID)
+		if e == provider.ErrAlreadyAdvertised {
+			e = nil
+		}
+		return e
+	}, retryWithBackoffInterval, retryWithBackoffMaxAttempts)
+
+	if err != nil {
+		return err
+	}
+	listener.stats.incRemoveAdsSent()
+
+	// removing the chunk from in-memory indexes
+	listener.chunker.removeChunk(chunk)
+
+	// marking the chunk as removed in the datastore. Removed chunks won't be re-loaded on next initialisation
+	chunk.Removed = true
+	err = listener.dsWrapper.recordChunkByContextID(ctx, chunk)
+	if err != nil {
+		chunk.Removed = false
+		listener.chunker.addChunk(chunk)
+		return err
+	}
+
+	return nil
+}
+
+func (listener *ReframeListener) notifyPutAndPersist(ctx context.Context, chunk *cidsChunk) error {
+	ctxIdStr := contextIDToStr(chunk.ContextID)
+	log.Infof("Notifying Put for chunk=%s, provider=%s, addrs=%q, cidsTotal=%d", ctxIdStr, listener.provider(), listener.addrs(), len(chunk.Cids))
+
+	// adding chunk into in-memory indexes so that multihash listed can find it
+	listener.chunker.addChunk(chunk)
+
+	// deleting the chunk from the datastore
+	err := RetryWithBackoff(func() error {
+		_, e := listener.engine.NotifyPut(ctx, &peer.AddrInfo{ID: listener.provider(), Addrs: listener.addrs()}, chunk.ContextID, bitswapMetadata)
+		if e == provider.ErrAlreadyAdvertised {
+			e = nil
+		}
+		return e
+	}, retryWithBackoffInterval, retryWithBackoffMaxAttempts)
+
+	if err != nil {
+		// if there was an error - reverting index update
+		listener.chunker.removeChunk(chunk)
+		return err
+	}
+
+	listener.stats.incPutAdsSent()
+
+	// updating the datastore
+	err = listener.dsWrapper.recordChunkByContextID(ctx, chunk)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (listener *ReframeListener) provider() peer.ID {
+	if listener.configuredProviderInfo == nil {
+		return listener.lastSeenProviderInfo.ID
+	}
+	return listener.configuredProviderInfo.ID
+}
+
+func (listener *ReframeListener) addrs() []multiaddr.Multiaddr {
+	if listener.configuredProviderInfo == nil {
+		return listener.lastSeenProviderInfo.Addrs
+	}
+	return listener.configuredProviderInfo.Addrs
+}
+
+func contextIDToStr(contextID []byte) string {
+	return base64.StdEncoding.EncodeToString(contextID)
+}
+
+func RetryWithBackoff(f func() error, initialInterval time.Duration, times int) error {
+	sleepTime := initialInterval
+	attempt := 0
+	for {
+		err := f()
+		if err == nil {
+			return nil
+		}
+		attempt++
+		if attempt == times {
+			return err
+		}
+		log.Infow("Retrying execution because of an error", "err", err, "attempt", attempt, "sleepTime", sleepTime)
+		time.Sleep(sleepTime)
+		sleepTime = sleepTime * 2
+	}
+}

--- a/reframe/listener_api_test.go
+++ b/reframe/listener_api_test.go
@@ -1,0 +1,121 @@
+package reframe
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/go-cid"
+)
+
+func ChunkExists(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {
+	cidsMap := cidsListToMap(cids)
+	ctxID := listener.chunker.generateContextID(cidsMap)
+	ctxIDStr := contextIDToStr(ctxID)
+	chunkFromIndex := listener.chunker.getChunkByContextID(ctxIDStr)
+	if chunkFromIndex == nil {
+		return false
+	}
+	cidsRegistered := true
+	for c := range chunkFromIndex.Cids {
+		chunkFromCidIndex := listener.chunker.getChunkByCID(c)
+		if chunkFromCidIndex == nil || contextIDToStr(chunkFromCidIndex.ContextID) != ctxIDStr {
+			cidsRegistered = false
+			break
+		}
+	}
+	if !cidsRegistered {
+		return false
+	}
+	chunkFromDatastore, err := listener.dsWrapper.getChunkByContextID(ctx, ctxID)
+	if err != nil {
+		return false
+	}
+	if contextIDToStr(chunkFromDatastore.ContextID) != ctxIDStr {
+		return false
+	}
+
+	return !chunkFromDatastore.Removed
+}
+
+func HasSnapshot(ctx context.Context, listener *ReframeListener) bool {
+	has, err := listener.dsWrapper.hasSanpshot(ctx)
+	return has && err == nil
+}
+
+func HasCidTimestamp(ctx context.Context, listener *ReframeListener, c cid.Cid) bool {
+	has, err := listener.dsWrapper.hasCidTimestamp(ctx, c)
+	return has && err == nil
+}
+
+func ChunkNotExist(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {
+	ctxID := listener.chunker.generateContextID(cidsListToMap(cids))
+	ctxIDStr := contextIDToStr(ctxID)
+	cidsRegistered := false
+	for _, c := range cids {
+		chunkFromIndex := listener.chunker.getChunkByCID(c)
+		if chunkFromIndex == nil || contextIDToStr(chunkFromIndex.ContextID) != ctxIDStr {
+			continue
+		}
+		cidsRegistered = true
+		break
+	}
+	if cidsRegistered {
+		return false
+	}
+
+	chunkFromDatastore, err := listener.dsWrapper.getChunkByContextID(ctx, ctxID)
+	if err != nil {
+		return false
+	}
+	return chunkFromDatastore.Removed && listener.chunker.getChunkByContextID(ctxIDStr) == nil
+
+}
+
+func CidExist(ctx context.Context, listener *ReframeListener, c cid.Cid, requireChunk bool) bool {
+	return listener.cidQueue.getNodeByCid(c) != nil && (!requireChunk || listener.chunker.getChunkByCID(c) != nil)
+}
+
+func CidNotExist(ctx context.Context, listener *ReframeListener, c cid.Cid) bool {
+	return listener.cidQueue.getNodeByCid(c) == nil && listener.chunker.getChunkByCID(c) == nil
+}
+
+func GetCidTimestamp(ctx context.Context, listener *ReframeListener, c cid.Cid) (time.Time, error) {
+	return listener.dsWrapper.getCidTimestamp(ctx, c)
+}
+
+func GetChunk(ctx context.Context, listener *ReframeListener, contextID string) *cidsChunk {
+	return listener.chunker.getChunkByContextID(contextID)
+}
+
+func GetCurrentChunk(ctx context.Context, listener *ReframeListener) *cidsChunk {
+	return listener.chunker.currentChunk
+}
+
+func GetExpiryQueue(ctx context.Context, listener *ReframeListener) []cid.Cid {
+	cids := make([]cid.Cid, listener.cidQueue.nodesLl.Len())
+	node := listener.cidQueue.nodesLl.Front()
+	cnt := 0
+	for {
+		if node == nil {
+			break
+		}
+		cids[cnt] = node.Value.(*cidNode).C
+		cnt++
+		node = node.Next()
+	}
+	return cids
+}
+
+func cidsListToMap(cids []cid.Cid) map[cid.Cid]struct{} {
+	cidsMap := make(map[cid.Cid]struct{})
+	for _, c := range cids {
+		cidsMap[c] = struct{}{}
+	}
+	return cidsMap
+}
+
+func StatsReporter() *statsReporter {
+
+	return &statsReporter{}
+
+}

--- a/reframe/listener_concurrency_test.go
+++ b/reframe/listener_concurrency_test.go
@@ -1,0 +1,114 @@
+//go:build !race
+
+package reframe_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine"
+	mock_provider "github.com/filecoin-project/index-provider/mock"
+	reframelistener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	leveldb "github.com/ipfs/go-ds-leveldb"
+	"github.com/libp2p/go-libp2p"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHandleConcurrentRequests(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 1000
+	snapshotSize := 1000
+	concurrencyFactor := 10
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+
+	cids := make([]cid.Cid, concurrencyFactor)
+	for i := 0; i < len(cids); i++ {
+		cids[i] = newCid(fmt.Sprintf("test%d", i))
+	}
+
+	prov := newProvider(t, pID)
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener, prov, priv)
+	defer server.Close()
+
+	chans := make([]chan bool, len(cids))
+	for i, c := range cids {
+		ch := make(chan bool, 1)
+		cc := c
+		chans[i] = ch
+		go func() {
+			provide(t, client, ctx, cc)
+			ch <- true
+		}()
+	}
+
+	for _, ch := range chans {
+		<-ch
+	}
+
+	for _, c := range cids {
+		require.True(t, reframelistener.CidExist(ctx, listener, c, false))
+	}
+}
+
+func TestShouldProcessMillionCIDsInThirtySeconds(t *testing.T) {
+	// this test can cause race detecting issues because of the stats reporter that gets accessed from multiple goroutines
+	cidsNumber := 1_000_000
+	timeExpectation := 30 * time.Second
+	chunkSize := 10000
+	snapshotSize := 1000
+	ttl := 24 * time.Hour
+
+	h, err := libp2p.New()
+	require.NoError(t, err)
+	priv, pID := generateKeyAndIdentity(t)
+	ctx := context.Background()
+
+	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
+	require.NoError(t, err)
+	err = engine.Start(ctx)
+	defer engine.Shutdown()
+	require.NoError(t, err)
+
+	tempDir := t.TempDir()
+	ds, err := leveldb.NewDatastore(tempDir, nil)
+	defer func() {
+		err = ds.Close()
+		require.NoError(t, err)
+	}()
+	require.NoError(t, err)
+
+	ip, err := reframelistener.New(ctx, engine, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	cids := make([]cid.Cid, cidsNumber)
+	for i := 0; i < len(cids); i++ {
+		cids[i] = newCid(fmt.Sprintf("test%d", i))
+	}
+
+	client, server := createClientAndServer(t, ip, newProvider(t, pID), priv)
+	defer server.Close()
+
+	start := time.Now()
+	provideMany(t, client, ctx, cids)
+
+	require.True(t, time.Since(start) < timeExpectation)
+
+}

--- a/reframe/listener_test.go
+++ b/reframe/listener_test.go
@@ -1,0 +1,1082 @@
+package reframe_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"fmt"
+	"net/http/httptest"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine"
+	"github.com/filecoin-project/index-provider/metadata"
+	mock_provider "github.com/filecoin-project/index-provider/mock"
+	reframelistener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/golang/mock/gomock"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-delegated-routing/client"
+	"github.com/ipfs/go-delegated-routing/gen/proto"
+	"github.com/ipfs/go-delegated-routing/server"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/multiformats/go-multicodec"
+	"github.com/multiformats/go-multihash"
+	"github.com/stretchr/testify/require"
+)
+
+var defaultMetadata metadata.Metadata = metadata.New(metadata.Bitswap{})
+
+func testNonceGen() []byte {
+	return []byte{1, 2, 3, 4, 5}
+}
+
+func newProvider(t *testing.T, pID peer.ID) *client.Provider {
+	ma, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/5001")
+	require.NoError(t, err)
+
+	return &client.Provider{
+		Peer: peer.AddrInfo{
+			ID:    pID,
+			Addrs: []multiaddr.Multiaddr{ma},
+		},
+		ProviderProto: []client.TransferProtocol{{Codec: multicodec.TransportBitswap}},
+	}
+}
+
+// TestReframeMultihashLister verifies that multihash lister returns correct number of multihashes in deterministic order
+func TestReframeMultihashLister(t *testing.T) {
+	cids := make(map[cid.Cid]struct{})
+	cids[newCid("test1")] = struct{}{}
+	cids[newCid("test2")] = struct{}{}
+	cids[newCid("test3")] = struct{}{}
+
+	_, pID := generateKeyAndIdentity(t)
+
+	lister := &reframelistener.ReframeMultihashLister{
+		CidFetcher: func(contextID []byte) (map[cid.Cid]struct{}, error) {
+			if string(contextID) == "test" {
+				return cids, nil
+			}
+			return nil, fmt.Errorf("unknown context id")
+		},
+	}
+
+	iterator, err := lister.MultihashLister(context.Background(), pID, []byte("test"))
+
+	require.NoError(t, err)
+	mhs := make([]multihash.Multihash, 0, len(cids))
+	for {
+		next, err := iterator.Next()
+		if err != nil {
+			break
+		}
+		mhs = append(mhs, next)
+	}
+
+	require.Equal(t, 3, len(mhs))
+	require.Equal(t, []multihash.Multihash{newCid("test1").Hash(), newCid("test2").Hash(), newCid("test3").Hash()}, mhs)
+}
+
+func TestRetryWithBackOffKeepsRetryingOnError(t *testing.T) {
+	// this test verifies that RetryWithBackOff keeps retrying as long as an error is returned or until the max number of attenpts is reached
+	start := time.Now()
+	attempts := 0
+	err := reframelistener.RetryWithBackoff(func() error {
+		attempts++
+		return fmt.Errorf("test")
+	}, time.Second, 3)
+
+	elapsed := time.Since(start)
+	require.Equal(t, 3, attempts)
+	// allow some error (1sec)
+	require.True(t, elapsed-3*time.Second < time.Second)
+	require.Equal(t, fmt.Errorf("test"), err)
+}
+
+func TestRetryWithBackOffStopsRetryingOnSuccess(t *testing.T) {
+	start := time.Now()
+	attempts := 0
+	err := reframelistener.RetryWithBackoff(func() error {
+		attempts++
+		return nil
+	}, time.Second, 3)
+
+	elapsed := time.Since(start)
+	require.Equal(t, 1, attempts)
+	require.True(t, elapsed < time.Second)
+	require.Nil(t, err)
+}
+
+func TestProvideRoundtrip(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+
+	h, err := libp2p.New()
+	require.NoError(t, err)
+	priv, pID := generateKeyAndIdentity(t)
+	ctx := context.Background()
+
+	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
+	require.NoError(t, err)
+	err = engine.Start(ctx)
+	defer engine.Shutdown()
+	require.NoError(t, err)
+
+	ip, err := reframelistener.New(ctx, engine, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	errorClient, errorServer := createClientAndServer(t, ip, nil, nil)
+	defer errorServer.Close()
+
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+
+	_, err = errorClient.Provide(ctx, []cid.Cid{testCid1}, time.Hour)
+	require.Error(t, err, "should get sync error on unsigned provide request.")
+	errorServer.Close()
+
+	client, server := createClientAndServer(t, ip, newProvider(t, pID), priv)
+	defer server.Close()
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2})
+
+	c, _, err := engine.GetLatestAdv(ctx)
+	require.NoError(t, err)
+	require.Equal(t, cid.Undef, c, "there should have been no advertisement published")
+
+	// two more cids should have pushed the first ad through
+	provideMany(t, client, ctx, []cid.Cid{testCid3, testCid4})
+
+	c, firstAd, err := engine.GetLatestAdv(ctx)
+	require.NoError(t, err)
+	require.NotEqual(t, cid.Undef, c)
+	require.NotNil(t, firstAd)
+	require.Equal(t, firstAd.ContextID, generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen()))
+	require.Nil(t, firstAd.PreviousID)
+
+	// pushing the second ad through
+	provide(t, client, ctx, testCid5)
+	_, secondAd, err := engine.GetLatestAdv(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, secondAd.PreviousID)
+	require.Equal(t, secondAd.ContextID, generateContextID([]string{testCid3.String(), testCid4.String()}, testNonceGen()))
+}
+
+func TestProvideRoundtripWithRemove(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 2
+	snapshotSize := 1000
+
+	h, err := libp2p.New()
+	require.NoError(t, err)
+	priv, pID := generateKeyAndIdentity(t)
+	ctx := context.Background()
+
+	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
+	require.NoError(t, err)
+	err = engine.Start(ctx)
+	defer engine.Shutdown()
+	require.NoError(t, err)
+
+	ip, err := reframelistener.New(ctx, engine, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	errorClient, errorServer := createClientAndServer(t, ip, nil, nil)
+	defer errorServer.Close()
+
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+
+	_, err = errorClient.Provide(ctx, []cid.Cid{testCid1}, time.Hour)
+	require.Error(t, err, "should get sync error on unsigned provide request.")
+	errorServer.Close()
+
+	client, server := createClientAndServer(t, ip, newProvider(t, pID), priv)
+	defer server.Close()
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+	time.Sleep(ttl)
+	provide(t, client, ctx, testCid1)
+
+	_, replacementAd, err := engine.GetLatestAdv(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, replacementAd)
+	require.Equal(t, replacementAd.ContextID, generateContextID([]string{testCid1.String()}, testNonceGen()))
+	require.False(t, replacementAd.IsRm)
+	require.NotNil(t, replacementAd.PreviousID)
+
+	rmAd, err := engine.GetAdv(ctx, replacementAd.PreviousID.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.Equal(t, rmAd.ContextID, generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen()))
+	require.True(t, rmAd.IsRm)
+	require.NotNil(t, rmAd.PreviousID)
+
+	firstAd, err := engine.GetAdv(ctx, rmAd.PreviousID.(cidlink.Link).Cid)
+	require.NoError(t, err)
+	require.NotNil(t, firstAd)
+	require.Equal(t, firstAd.ContextID, generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen()))
+	require.False(t, firstAd.IsRm)
+	require.Nil(t, firstAd.PreviousID)
+}
+
+func TestAdvertiseTwoChunksWithOneCidInEach(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	ip, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, ip, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+}
+
+func TestAdvertiseUsingAddrsFromParameters(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	randomMultiaddr, err := multiaddr.NewMultiaddr("/ip4/0.0.0.0/tcp/1001")
+	require.NoError(t, err)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&peer.AddrInfo{ID: pID, Addrs: []multiaddr.Multiaddr{randomMultiaddr}}), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&peer.AddrInfo{ID: pID, Addrs: []multiaddr.Multiaddr{randomMultiaddr}}), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	ip, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, pID.String(), []string{"/ip4/0.0.0.0/tcp/1001"}, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, ip, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+}
+
+func TestProvideRegistersCidInDatastore(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid1, false))
+
+	// verifying that the CID has a current timestamp
+	tt, err := reframelistener.GetCidTimestamp(ctx, listener, testCid1)
+	require.NoError(t, err)
+	require.True(t, time.Since(tt) < time.Second)
+	require.Equal(t, []cid.Cid{testCid1}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestCidsAreOrderedByArrivalInExpiryQueue(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 1000
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid2)
+	provide(t, c, ctx, testCid3)
+	require.Equal(t, []cid.Cid{testCid3, testCid2, testCid1}, reframelistener.GetExpiryQueue(ctx, listener))
+
+	provide(t, c, ctx, testCid2)
+	require.Equal(t, []cid.Cid{testCid2, testCid3, testCid1}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestFullChunkAdvertisedAndRegisteredInDatastore(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid1, true))
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid2, true))
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid3, false))
+	require.True(t, reframelistener.ChunkExists(ctx, listener, []cid.Cid{testCid1, testCid2}, testNonceGen))
+	require.Equal(t, []cid.Cid{testCid3, testCid2, testCid1}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestRemovedChunkIsRemovedFromIndexes(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2})
+	time.Sleep(ttl)
+	provide(t, c, ctx, testCid3)
+
+	require.True(t, reframelistener.ChunkNotExist(ctx, listener, []cid.Cid{testCid1, testCid2}, testNonceGen))
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid3, false))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid1))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid2))
+	require.Equal(t, []cid.Cid{testCid3}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestAdvertiseOneChunkWithTwoCidsInIt(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+}
+
+func TestDoNotReAdvertiseRepeatedCids(t *testing.T) {
+	ttl := 24 * time.Hour
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid2)
+	provide(t, c, ctx, testCid2)
+	provide(t, c, ctx, testCid2)
+}
+
+func TestAdvertiseExpiredCidsIfProvidedAgain(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	time.Sleep(time.Second)
+	// by the time testCid2 gets published, testCid1 already expired that should geenrate a remove ad
+	provide(t, c, ctx, testCid2)
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid3)
+}
+
+func TestRemoveExpiredCidAndReadvertiseChunk(t *testing.T) {
+	ttl := 3 * time.Second
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Any(), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	time.Sleep(2 * time.Second)
+	provide(t, c, ctx, testCid2)
+	time.Sleep(2 * time.Second)
+	provide(t, c, ctx, testCid3)
+
+	// verifying ds and indexes
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid2, true))
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid3, false))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid1))
+	require.True(t, reframelistener.ChunkExists(ctx, listener, []cid.Cid{testCid2}, testNonceGen))
+	require.True(t, reframelistener.ChunkNotExist(ctx, listener, []cid.Cid{testCid1, testCid2}, testNonceGen))
+	require.Equal(t, []cid.Cid{testCid3, testCid2}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestExpireMultipleChunks(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid3.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid2.String()}, testNonceGen())))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid3.String()}, testNonceGen())))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+	time.Sleep(1 * time.Second)
+	provide(t, c, ctx, testCid4)
+}
+
+func TestDoNotReadvertiseChunkIfAllCidsExpired(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())))
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	time.Sleep(2 * time.Second)
+	provide(t, c, ctx, testCid2)
+
+	// verifying ds and indexes
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid2, false))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid1))
+	require.True(t, reframelistener.ChunkNotExist(ctx, listener, []cid.Cid{testCid1}, testNonceGen))
+	require.Equal(t, []cid.Cid{testCid2}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestDoNoLoadRemovedChunksOnInitialisation(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 1
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String()}, testNonceGen())))
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener1, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener1, prov, priv)
+
+	provide(t, c, ctx, testCid1)
+	time.Sleep(ttl)
+	provide(t, c, ctx, testCid2)
+
+	s.Close()
+
+	listener2, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	require.True(t, reframelistener.ChunkNotExist(ctx, listener2, []cid.Cid{testCid1}, testNonceGen))
+}
+
+func TestSameCidNotDuplicatedInTheCurrentChunkIfProvidedTwice(t *testing.T) {
+	ttl := time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), nil)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, newProvider(t, pID), priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid1)
+	provide(t, c, ctx, testCid1)
+}
+
+func TestShouldStoreSnapshotInDatastore(t *testing.T) {
+	snapshotSize := 2
+	ttl := time.Hour
+	chunkSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener, prov, priv)
+	defer server.Close()
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2, testCid3, testCid4, testCid5})
+	provide(t, client, ctx, testCid1)
+	provide(t, client, ctx, testCid2)
+
+	require.True(t, reframelistener.HasSnapshot(ctx, listener))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid1))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid2))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener, testCid3))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener, testCid4))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener, testCid5))
+}
+
+func TestShouldNotStoreSnapshotInDatastore(t *testing.T) {
+	snapshotSize := 10
+	ttl := time.Hour
+	chunkSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener, prov, priv)
+	defer server.Close()
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2, testCid3, testCid4, testCid5})
+
+	require.False(t, reframelistener.HasSnapshot(ctx, listener))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid1))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid2))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid3))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid4))
+	require.True(t, reframelistener.HasCidTimestamp(ctx, listener, testCid5))
+}
+
+func TestShouldCleanUpTimestampMappingsFromDatastore(t *testing.T) {
+	snapshotSize := 2
+	ttl := time.Hour
+	chunkSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener1, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener1, prov, priv)
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2, testCid3, testCid4, testCid5})
+	provide(t, client, ctx, testCid1)
+	provide(t, client, ctx, testCid2)
+
+	server.Close()
+
+	listener2, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	require.True(t, reframelistener.HasSnapshot(ctx, listener2))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener2, testCid1))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener2, testCid2))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener2, testCid3))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener2, testCid4))
+	require.False(t, reframelistener.HasCidTimestamp(ctx, listener2, testCid5))
+}
+
+func TestShouldCorrectlyMergeSnapshotAndCidTimestamps(t *testing.T) {
+	snapshotSize := 2
+	ttl := time.Hour
+	chunkSize := 1000
+
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener1, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener1, prov, priv)
+
+	provideMany(t, client, ctx, []cid.Cid{testCid1, testCid2, testCid3, testCid4, testCid5})
+	provide(t, client, ctx, testCid3)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid1)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid4)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid5)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid2)
+
+	server.Close()
+
+	listener2, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	require.Equal(t, []cid.Cid{testCid2, testCid5, testCid4, testCid1, testCid3}, reframelistener.GetExpiryQueue(ctx, listener2))
+}
+
+func TestInitialiseFromDatastoreWithoutSnapshot(t *testing.T) {
+	verifyInitialisationFromDatastore(t, 10, time.Hour, 2)
+}
+
+func TestInitialiseFromDatastoreWithSnapshot(t *testing.T) {
+	verifyInitialisationFromDatastore(t, 2, time.Hour, 2)
+}
+
+func verifyInitialisationFromDatastore(t *testing.T, snapshotSize int, ttl time.Duration, chunkSize int) {
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid4 := newCid("test4")
+	testCid5 := newCid("test5")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid3.String(), testCid4.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	ds := datastore.NewMapDatastore()
+	listener1, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	client, server := createClientAndServer(t, listener1, prov, priv)
+
+	provide(t, client, ctx, testCid1)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid2)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid3)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid4)
+	time.Sleep(100 * time.Millisecond)
+	provide(t, client, ctx, testCid5)
+
+	server.Close()
+
+	listener2, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	require.True(t, reframelistener.ChunkExists(ctx, listener2, []cid.Cid{testCid1, testCid2}, testNonceGen))
+	require.True(t, reframelistener.ChunkExists(ctx, listener2, []cid.Cid{testCid3, testCid4}, testNonceGen))
+	require.True(t, reframelistener.CidExist(ctx, listener2, testCid1, true))
+	require.True(t, reframelistener.CidExist(ctx, listener2, testCid2, true))
+	require.True(t, reframelistener.CidExist(ctx, listener2, testCid3, true))
+	require.True(t, reframelistener.CidExist(ctx, listener2, testCid4, true))
+	require.True(t, reframelistener.CidExist(ctx, listener2, testCid5, false))
+	require.Equal(t, []cid.Cid{testCid5, testCid4, testCid3, testCid2, testCid1}, reframelistener.GetExpiryQueue(ctx, listener2))
+}
+
+func TestCleanUpExpiredCidsThatDontHaveChunk(t *testing.T) {
+	ttl := time.Second
+	chunkSize := 2
+	snapshotSize := 1000
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+	testCid2 := newCid("test2")
+	testCid3 := newCid("test3")
+	testCid100 := newCid("test100")
+	prov := newProvider(t, pID)
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+	mockEng.EXPECT().NotifyPut(gomock.Any(), gomock.Eq(&prov.Peer), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())), gomock.Eq(defaultMetadata))
+	mockEng.EXPECT().NotifyRemove(gomock.Any(), gomock.Eq(pID), gomock.Eq(generateContextID([]string{testCid1.String(), testCid2.String()}, testNonceGen())))
+
+	ds := datastore.NewMapDatastore()
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, ds, testNonceGen)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, prov, priv)
+	defer s.Close()
+
+	provideMany(t, c, ctx, []cid.Cid{testCid1, testCid2, testCid3})
+
+	time.Sleep(2 * time.Second)
+
+	provide(t, c, ctx, testCid100)
+
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid3))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid2))
+	require.True(t, reframelistener.CidNotExist(ctx, listener, testCid1))
+	require.Equal(t, []cid.Cid{testCid100}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func TestCidsWithoutChunkAreRegisteredInDsAndIndexes(t *testing.T) {
+	ttl := 1 * time.Hour
+	chunkSize := 2
+	snapshotSize := 1000
+	priv, pID := generateKeyAndIdentity(t)
+
+	ctx := context.Background()
+	defer ctx.Done()
+	testCid1 := newCid("test1")
+
+	mc := gomock.NewController(t)
+	defer mc.Finish()
+	mockEng := mock_provider.NewMockInterface(mc)
+
+	mockEng.EXPECT().RegisterMultihashLister(gomock.Any())
+
+	listener, err := reframelistener.New(ctx, mockEng, ttl, chunkSize, snapshotSize, "", nil, datastore.NewMapDatastore(), nil)
+	require.NoError(t, err)
+
+	c, s := createClientAndServer(t, listener, newProvider(t, pID), priv)
+	defer s.Close()
+
+	provide(t, c, ctx, testCid1)
+
+	require.True(t, reframelistener.CidExist(ctx, listener, testCid1, false))
+	require.Equal(t, []cid.Cid{testCid1}, reframelistener.GetExpiryQueue(ctx, listener))
+}
+
+func provide(t *testing.T, cc *client.Client, ctx context.Context, c cid.Cid) time.Duration {
+	return provideMany(t, cc, ctx, []cid.Cid{c})
+}
+
+func provideMany(t *testing.T, cc *client.Client, ctx context.Context, cids []cid.Cid) time.Duration {
+	rc, err := cc.Provide(ctx, cids, 2*time.Hour)
+	require.NoError(t, err)
+	return rc
+}
+
+func generateContextID(cids []string, nonce []byte) []byte {
+	sort.Strings(cids)
+	hasher := sha256.New()
+	for _, c := range cids {
+		hasher.Write([]byte(c))
+	}
+	hasher.Write(nonce)
+	return hasher.Sum(nil)
+}
+
+func newCid(s string) cid.Cid {
+	testMH1, _ := multihash.Encode([]byte(s), multihash.IDENTITY)
+	return cid.NewCidV1(cid.Raw, testMH1)
+}
+
+func generateKeyAndIdentity(t *testing.T) (crypto.PrivKey, peer.ID) {
+	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	require.NoError(t, err)
+	pID, err := peer.IDFromPrivateKey(priv)
+	require.NoError(t, err)
+	return priv, pID
+}
+
+func createClientAndServer(t *testing.T, service server.DelegatedRoutingService, p *client.Provider, identity crypto.PrivKey) (*client.Client, *httptest.Server) {
+	// start a server
+	s := httptest.NewServer(server.DelegatedRoutingAsyncHandler(service))
+
+	// start a client
+	q, err := proto.New_DelegatedRouting_Client(s.URL, proto.DelegatedRouting_Client_WithHTTPClient(s.Client()))
+	require.NoError(t, err)
+	c, err := client.NewClient(q, p, identity)
+	require.NoError(t, err)
+
+	return c, s
+}

--- a/reframe/stats_reporter.go
+++ b/reframe/stats_reporter.go
@@ -1,0 +1,93 @@
+package reframe
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+type statsReporter struct {
+	s                    *stats
+	totalCidsFunc        func() int
+	totalChunksFunc      func() int
+	currentChunkSizeFunc func() int
+	statsTicker          chan bool
+}
+
+type stats struct {
+	putAdsSent            int64
+	removeAdsSent         int64
+	cidsProcessed         int64
+	existingCidsProcessed int64
+	cidsExpired           int64
+	reframeCallsReceived  int64
+	reframeCallsProcessed int64
+	chunkCacheMisses      int64
+	chunksNotFound        int64
+}
+
+func newStatsReporter(totalCidsFunc func() int, totalChunksFunc func() int, currentChunkSizeFunc func() int) *statsReporter {
+	return &statsReporter{
+		s:                    &stats{},
+		totalCidsFunc:        totalCidsFunc,
+		totalChunksFunc:      totalChunksFunc,
+		currentChunkSizeFunc: currentChunkSizeFunc,
+	}
+}
+
+func (reporter *statsReporter) incPutAdsSent() {
+	reporter.s.putAdsSent++
+}
+
+func (reporter *statsReporter) incRemoveAdsSent() {
+	reporter.s.removeAdsSent++
+}
+
+func (reporter *statsReporter) incCidsProcessed() {
+	reporter.s.cidsProcessed++
+}
+
+func (reporter *statsReporter) incExistingCidsProcessed() {
+	reporter.s.existingCidsProcessed++
+}
+
+func (reporter *statsReporter) incCidsExpired() {
+	reporter.s.cidsExpired++
+}
+
+func (reporter *statsReporter) incReframeCallsReceived() {
+	// needs to be threadsafe as it gets called from the webserver handler
+	atomic.AddInt64(&reporter.s.reframeCallsReceived, 1)
+}
+
+func (reporter *statsReporter) incReframeCallsProcessed() {
+	reporter.s.reframeCallsProcessed++
+}
+
+func (reporter *statsReporter) incChunkCacheMisses() {
+	reporter.s.chunkCacheMisses++
+}
+
+func (reporter *statsReporter) incChunksNotFound() {
+	reporter.s.chunksNotFound++
+}
+
+func (reporter *statsReporter) start() {
+	reporter.statsTicker = make(chan bool)
+	ticker := time.NewTicker(statsPrintFrequency)
+
+	go func() {
+		for {
+			select {
+			case <-reporter.statsTicker:
+				ticker.Stop()
+				return
+			case <-ticker.C:
+				log.Infof("stats: %+v, totalCids: %d, totalChunks: %d, currentChunkSize: %d", reporter.s, reporter.totalCidsFunc(), reporter.totalChunksFunc(), reporter.currentChunkSizeFunc())
+			}
+		}
+	}()
+}
+
+func (reporter *statsReporter) shutdown() {
+	reporter.statsTicker <- true
+}

--- a/server/reframe/http/options.go
+++ b/server/reframe/http/options.go
@@ -1,0 +1,55 @@
+package reframeserver
+
+import "time"
+
+type (
+	// Option captures a configurable parameter in admin HTTP server.
+	Option func(*options) error
+
+	options struct {
+		listenAddr   string
+		readTimeout  time.Duration
+		writeTimeout time.Duration
+	}
+)
+
+func newOptions(o ...Option) (*options, error) {
+	opts := &options{
+		listenAddr:   "",
+		readTimeout:  30 * time.Second,
+		writeTimeout: 30 * time.Second,
+	}
+
+	for _, apply := range o {
+		if err := apply(opts); err != nil {
+			return nil, err
+		}
+	}
+	return opts, nil
+}
+
+// WithListenAddr sets the net address on which the reframe HTTP server is exposed.
+func WithListenAddr(addr string) Option {
+	return func(o *options) error {
+		o.listenAddr = addr
+		return nil
+	}
+}
+
+// WithReadTimeout set s the HTTP read timeout.
+// If unset, the default of 30 seconds is used.
+func WithReadTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.readTimeout = t
+		return nil
+	}
+}
+
+// WithWriteTimeout sets the HTTP write timeout.
+// If unset, the default of 30 seconds is used.
+func WithWriteTimeout(t time.Duration) Option {
+	return func(o *options) error {
+		o.writeTimeout = t
+		return nil
+	}
+}

--- a/server/reframe/http/server.go
+++ b/server/reframe/http/server.go
@@ -1,0 +1,72 @@
+package reframeserver
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	provider "github.com/filecoin-project/index-provider"
+	reframelistener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/ipfs/go-datastore"
+	drserver "github.com/ipfs/go-delegated-routing/server"
+	logging "github.com/ipfs/go-log/v2"
+)
+
+var log = logging.Logger("adminserver")
+
+type Server struct {
+	server      *http.Server
+	netListener net.Listener
+	rListener   *reframelistener.ReframeListener
+}
+
+func New(cidTtl time.Duration,
+	chunkSize int,
+	snapshotSize int,
+	providerID string,
+	addrs []string,
+	e provider.Interface,
+	ds datastore.Batching,
+	o ...Option) (*Server, error) {
+
+	opts, err := newOptions(o...)
+	if err != nil {
+		return nil, err
+	}
+	netListener, err := net.Listen("tcp", opts.listenAddr)
+	if err != nil {
+		return nil, fmt.Errorf("reframe initialisation failed: %s", err)
+	}
+
+	rListener, err := reframelistener.New(context.Background(), e, cidTtl, chunkSize, snapshotSize, providerID, addrs, ds, nil)
+	if err != nil {
+		return nil, fmt.Errorf("reframe initialisation failed: %s", err)
+	}
+
+	handler := drserver.DelegatedRoutingAsyncHandler(rListener)
+
+	s := &http.Server{
+		Handler:      handler,
+		ReadTimeout:  opts.readTimeout,
+		WriteTimeout: opts.writeTimeout,
+	}
+
+	return &Server{
+		server:      s,
+		netListener: netListener,
+		rListener:   rListener,
+	}, nil
+}
+
+func (s *Server) Start() error {
+	log.Infow("reframe http server listening", "addr", s.netListener.Addr())
+	return s.server.Serve(s.netListener)
+}
+
+func (s *Server) Shutdown(ctx context.Context) error {
+	log.Info("reframe http server shutdown")
+	s.rListener.Shutdown()
+	return s.server.Shutdown(ctx)
+}


### PR DESCRIPTION
This PR adds a capability for exposing a [reframe server](https://github.com/ipfs/go-delegated-routing) from the index-provider daemon. Reframe server allows IPFS node to advertise its contents to indexers alongside DHT via the [delegated routing protocol](https://github.com/ipfs/specs/blob/main/reframe/REFRAME_PROTOCOL.md) . 

Reframe server can optionally be exposed as a part of `daemon` command by adding a `Reframe` configuration block, which is off by default. 

Kubo advertises its content via snapshots containing all of its CID.  Snapshots are re-published every 12 hours. Single CIDs can also be advertised upon pinning to the node. The reframe server chunks up the received CIDs and advertises them to the indexers via the `NotifyPut` as chunks get full. A chunk maps one-to-one to an indexer ad. Context IDs are deterministically calculated as a sha256 sum over the ordered sequence of CIDs + nonce. If a CID disappears between two consecutive snapshots it is considered removed. That leads to a`Remove` advertisement of the chunk containing that CID and then republishing of it less the CID itself. 

Reframe server uses engine's datastore and supports re-initialisation of its state upon restart. 

This is an initial implementation that has a few shortcuts (highlighted as TODO's in the code). 