### PR TITLE
Auto generate identity if one hasn't been provided in json config

### DIFF
--- a/cmd/provider/daemon.go
+++ b/cmd/provider/daemon.go
@@ -66,7 +66,7 @@ func daemonCommand(cctx *cli.Context) error {
 	ctx, cancelp2p := context.WithCancel(cctx.Context)
 	defer cancelp2p()
 
-	peerID, privKey, err := cfg.Identity.Decode()
+	peerID, privKey, err := cfg.Identity.DecodeOrCreate(cctx.App.Writer)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/index.go
+++ b/cmd/provider/index.go
@@ -51,7 +51,7 @@ func indexCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	peerID, privKey, err := cfg.Identity.Decode()
+	peerID, privKey, err := cfg.Identity.DecodeOrCreate(cctx.App.Writer)
 	if err != nil {
 		return err
 	}

--- a/cmd/provider/internal/config/identity.go
+++ b/cmd/provider/internal/config/identity.go
@@ -2,10 +2,17 @@ package config
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
+	"io"
+	"os"
 
 	ic "github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+const (
+	PrivateKeyPathEnvVar = "INDEXPROVIDER_PRIV_KEY_PATH"
 )
 
 // Identity tracks the configuration of the local node's identity.
@@ -14,28 +21,91 @@ type Identity struct {
 	PrivKey string `json:",omitempty"`
 }
 
-func (i Identity) Decode() (peer.ID, ic.PrivKey, error) {
-	peerID, err := peer.Decode(i.PeerID)
-	if err != nil {
-		return "", nil, fmt.Errorf("could not decode peer id: %s", err)
-	}
+func (identity Identity) DecodeOrCreate(out io.Writer) (peer.ID, ic.PrivKey, error) {
 
-	privKey, err := i.DecodePrivateKey("")
+	privKey, err := identity.DecodeOrCreatePrivateKey(out, "")
 	if err != nil {
 		return "", nil, fmt.Errorf("could not decode private key: %s", err)
 	}
 
-	return peerID, privKey, nil
+	peerIDFromPrivKey, err := peer.IDFromPrivateKey(privKey)
+	if err != nil {
+		return "", nil, fmt.Errorf("could not decode peer id: %s", err)
+	}
+
+	// If peer ID is specified in JSON config, then verify that it is:
+	//   1. a valid peer ID, and
+	//   2. consistent with the peer ID generated from private key.
+	if identity.PeerID != "" {
+		peerID, err := peer.Decode(identity.PeerID)
+		if err != nil {
+			return "", nil, fmt.Errorf("could not decode peer id: %w", err)
+		}
+
+		if peerID != "" && peerIDFromPrivKey != peerID {
+			return "", nil, fmt.Errorf("provided peer ID must either match the peer ID generated from private key or be omitted: expected %s but got %s", peerIDFromPrivKey, peerID)
+		}
+	}
+
+	return peerIDFromPrivKey, privKey, nil
 }
 
-// DecodePrivateKey is a helper to decode the user's PrivateKey.
-func (i Identity) DecodePrivateKey(passphrase string) (ic.PrivKey, error) {
-	pkb, err := base64.StdEncoding.DecodeString(i.PrivKey)
+// DecodeOrCreatePrivateKey is a helper to decode the user's PrivateKey. If the key hasn't been provided in json config
+// then it's going to be read from PrivateKeyPathEnvVar. If that file doesn't exist then a new key is going to be generated and saved there.
+func (identity Identity) DecodeOrCreatePrivateKey(out io.Writer, passphrase string) (ic.PrivKey, error) {
+	if identity.PrivKey == "" {
+		pkb, err := loadPrivKeyFromFile(out)
+		if err != nil {
+			return nil, err
+		}
+		return ic.UnmarshalPrivateKey(pkb)
+	}
+
+	pkb, err := base64.StdEncoding.DecodeString(identity.PrivKey)
+	if err != nil {
+		return nil, err
+	}
+	return ic.UnmarshalPrivateKey(pkb)
+}
+
+func loadPrivKeyFromFile(out io.Writer) ([]byte, error) {
+	privKeyPath := os.Getenv(PrivateKeyPathEnvVar)
+	if privKeyPath == "" {
+		return nil, fmt.Errorf("private key not specified; it must be specified either in config or via %s env var", PrivateKeyPathEnvVar)
+	}
+
+	// If the file with key doesn't exist - generate a new key and save it to the file
+	if _, err := os.Stat(privKeyPath); errors.Is(err, os.ErrNotExist) {
+		pk, err := generateAndSavePrivKey(out, privKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		return pk, nil
+	}
+	pkb, err := os.ReadFile(privKeyPath)
+	if err != nil {
+		return nil, err
+	}
+	return pkb, nil
+}
+
+func generateAndSavePrivKey(out io.Writer, filePath string) ([]byte, error) {
+	identity, err := CreateIdentity(out)
 	if err != nil {
 		return nil, err
 	}
 
-	// currently storing key unencrypted. in the future we need to encrypt it.
-	// TODO(security)
-	return ic.UnmarshalPrivateKey(pkb)
+	f, err := os.Create(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	pkb, err := base64.StdEncoding.DecodeString(identity.PrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = f.Write(pkb)
+	return pkb, err
 }

--- a/cmd/provider/internal/config/identity_test.go
+++ b/cmd/provider/internal/config/identity_test.go
@@ -1,0 +1,54 @@
+package config
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	ic "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeOrCreate(t *testing.T) {
+	// first, creating an identity and saving the key to the file
+	identity := Identity{}
+	privKeyPath := filepath.Join(t.TempDir(), "privKey")
+	t.Setenv(PrivateKeyPathEnvVar, privKeyPath)
+
+	peerIDBefore, pkBefore, err := identity.DecodeOrCreate(io.Discard)
+	require.NoError(t, err)
+
+	stat, err := os.Stat(privKeyPath)
+	require.NoError(t, err)
+	modTimeBefore := stat.ModTime()
+
+	// verifying that once the file is there, the new identity is going to be read from it
+	identityFromPrivateKey := Identity{}
+	peerIDAfter, pkAfter, err := identityFromPrivateKey.DecodeOrCreate(io.Discard)
+	require.NoError(t, err)
+
+	require.Equal(t, pkBefore, pkAfter)
+	require.Equal(t, peerIDBefore, peerIDAfter)
+
+	stat, err = os.Stat(privKeyPath)
+	require.NoError(t, err)
+
+	// verifying that the file hasn't changed between runs
+	require.Equal(t, modTimeBefore, stat.ModTime())
+
+	pkb, err := os.ReadFile(privKeyPath)
+	require.NoError(t, err)
+	pkFromFile, err := ic.UnmarshalPrivateKey(pkb)
+	require.NoError(t, err)
+
+	// verifying that the key in the file matches the one returned by the function
+	require.Equal(t, pkFromFile, pkAfter)
+
+	peerIDFromFile, err := peer.IDFromPrivateKey(pkFromFile)
+	require.NoError(t, err)
+
+	// verifying that the identity from the file matches the one returned by the function
+	require.Equal(t, peerIDFromFile, peerIDAfter)
+}

--- a/cmd/provider/internal/config/init_test.go
+++ b/cmd/provider/internal/config/init_test.go
@@ -15,7 +15,7 @@ func TestCreateIdentity(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	pk, err := id.DecodePrivateKey("")
+	pk, err := id.DecodeOrCreatePrivateKey(io.Discard, "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/provider/register.go
+++ b/cmd/provider/register.go
@@ -21,7 +21,7 @@ func registerCommand(cctx *cli.Context) error {
 		return err
 	}
 
-	peerID, privKey, err := cfg.Identity.Decode()
+	peerID, privKey, err := cfg.Identity.DecodeOrCreate(cctx.App.Writer)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The PR adds an ability to read a private key from a file if one hasn't been provided in the json config (similarly to `storetheindex`). If a key is neither in the config or a file - a new key is going to be generated and saved to the disk. 

Path to the file with private key is driven by `INDEXPROVIDER_PRIV_KEY_PATH ` environment variable. If neither config nor the var have been provided - the program will error out. 

This functionality has been requested by `bifrost-infra` in their efforts to automate `index-provider` deployments. CC @hsanjuan 