### PR TITLE
Split reframe snapshot into multiple chunks

### DIFF
--- a/reframe/listener.go
+++ b/reframe/listener.go
@@ -85,15 +85,18 @@ func New(ctx context.Context, engine provider.Interface,
 	providerId string,
 	addresses []string,
 	ds datastore.Datastore,
-	nonceGen func() []byte) (*ReframeListener, error) {
+	nonceGen func() []byte,
+	opts ...Option,
+) (*ReframeListener, error) {
+
+	options := ApplyOptions(opts...)
 
 	listener := &ReframeListener{
-		engine:       engine,
-		cidTtl:       cidTtl,
-		chunkSize:    chunkSize,
-		snapshotSize: snapshotSize,
-		dsWrapper: &dsWrapper{
-			ds: namespace.Wrap(ds, datastore.NewKey(reframeDSName))},
+		engine:                 engine,
+		cidTtl:                 cidTtl,
+		chunkSize:              chunkSize,
+		snapshotSize:           snapshotSize,
+		dsWrapper:              newDSWrapper(namespace.Wrap(ds, datastore.NewKey(reframeDSName)), options.SnapshotMaxChunkSize),
 		lastSeenProviderInfo:   &peer.AddrInfo{},
 		configuredProviderInfo: nil,
 		chunker:                newChunker(func() int { return chunkSize }, nonceGen),

--- a/reframe/listener_api_test.go
+++ b/reframe/listener_api_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
 )
 
 func ChunkExists(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {
@@ -38,13 +39,21 @@ func ChunkExists(ctx context.Context, listener *ReframeListener, cids []cid.Cid,
 }
 
 func HasSnapshot(ctx context.Context, listener *ReframeListener) bool {
-	has, err := listener.dsWrapper.hasSanpshot(ctx)
-	return has && err == nil
+	return SnapshotsQty(ctx, listener) > 0
+}
+
+func SnapshotsQty(ctx context.Context, listener *ReframeListener) int {
+	keys, _ := listener.dsWrapper.getSnapshotChunkKeys(ctx)
+	return len(keys)
 }
 
 func HasCidTimestamp(ctx context.Context, listener *ReframeListener, c cid.Cid) bool {
-	has, err := listener.dsWrapper.hasCidTimestamp(ctx, c)
+	has, err := listener.dsWrapper.ds.Has(ctx, timestampByCidKey(c))
 	return has && err == nil
+}
+
+func WrappedDatastore(listener *ReframeListener) datastore.Datastore {
+	return listener.dsWrapper.ds
 }
 
 func ChunkNotExist(ctx context.Context, listener *ReframeListener, cids []cid.Cid, nonceGen func() []byte) bool {

--- a/reframe/options.go
+++ b/reframe/options.go
@@ -1,0 +1,29 @@
+package reframe
+
+const (
+	defaultSnapshotMaxChunkSize = 1_000_000
+)
+
+type Options struct {
+	// SnapshotMaxChunkSize defines a size of a chunk that CID snapshot is going to be split into before stored in the datastore.
+	// Needed as leveldb can't handle binary payloads above a certain threshold
+	SnapshotMaxChunkSize int
+}
+
+type Option func(*Options)
+
+func WithSnapshotMaxChunkSize(i int) Option {
+	return func(o *Options) {
+		o.SnapshotMaxChunkSize = i
+	}
+}
+
+func ApplyOptions(opt ...Option) Options {
+	opts := Options{
+		SnapshotMaxChunkSize: defaultSnapshotMaxChunkSize,
+	}
+	for _, o := range opt {
+		o(&opts)
+	}
+	return opts
+}

--- a/reframe/options_test.go
+++ b/reframe/options_test.go
@@ -1,0 +1,13 @@
+package reframe_test
+
+import (
+	"testing"
+
+	reframeListener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOptionsDefaults(t *testing.T) {
+	opts := reframeListener.ApplyOptions()
+	require.Equal(t, 1_000_000, opts.SnapshotMaxChunkSize)
+}


### PR DESCRIPTION
Split reframe snapshot into multiple chunks as leveldb has a constraint on maximum size of binary blobs. 