### PR TITLE
Replace dependency on go-legs with storetheindex

### DIFF
--- a/cmd/provider/internal/client.go
+++ b/cmd/provider/internal/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/filecoin-project/go-legs"
+	"github.com/filecoin-project/storetheindex/dagsync"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	logging "github.com/ipfs/go-log/v2"
@@ -26,7 +26,7 @@ type (
 	}
 	providerClient struct {
 		*options
-		sub *legs.Subscriber
+		sub *dagsync.Subscriber
 
 		store     *ProviderClientStore
 		publisher peer.AddrInfo
@@ -48,7 +48,7 @@ func NewProviderClient(provAddr peer.AddrInfo, o ...Option) (ProviderClient, err
 	h.Peerstore().AddAddrs(provAddr.ID, provAddr.Addrs, time.Hour)
 
 	store := newProviderClientStore()
-	sub, err := legs.NewSubscriber(h, store.Batching, store.LinkSystem, opts.topic, nil)
+	sub, err := dagsync.NewSubscriber(h, store.Batching, store.LinkSystem, opts.topic, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/provider/internal/config/ingest.go
+++ b/cmd/provider/internal/config/ingest.go
@@ -31,10 +31,10 @@ type Ingest struct {
 	// PurgeLinkCache tells whether to purge the link cache on daemon startup.
 	PurgeLinkCache bool
 
-	// HttpPublisher configures the go-legs httpsync publisher.
+	// HttpPublisher configures the dagsync httpsync publisher.
 	HttpPublisher HttpPublisher
 
-	// PublisherKind specifies which legs.Publisher implementation to use.
+	// PublisherKind specifies which dagsync.Publisher implementation to use.
 	PublisherKind PublisherKind
 
 	// SyncPolicy configures which indexers are allowed to sync advertisements

--- a/cmd/provider/mirror.go
+++ b/cmd/provider/mirror.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/filecoin-project/index-provider/metrics"
 	"github.com/filecoin-project/index-provider/mirror"
@@ -152,8 +151,7 @@ func beforeMirror(cctx *cli.Context) error {
 		return err
 	}
 	if cctx.IsSet(Mirror.flags.syncInterval.Name) {
-		ticker := time.NewTicker(Mirror.flags.syncInterval.Get(cctx))
-		Mirror.options = append(Mirror.options, mirror.WithSyncInterval(ticker))
+		Mirror.options = append(Mirror.options, mirror.WithSyncInterval(Mirror.flags.syncInterval.Get(cctx)))
 	}
 	var hostOpts []libp2p.Option
 	if cctx.IsSet(Mirror.flags.identityPath.Name) {

--- a/e2e_retrieve_test.go
+++ b/e2e_retrieve_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	datatransfer "github.com/filecoin-project/go-data-transfer"
-	"github.com/filecoin-project/go-legs"
 	provider "github.com/filecoin-project/index-provider"
 	"github.com/filecoin-project/index-provider/cardatatransfer"
 	"github.com/filecoin-project/index-provider/engine"
@@ -18,6 +17,7 @@ import (
 	"github.com/filecoin-project/index-provider/supplier"
 	"github.com/filecoin-project/index-provider/testutil"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/dagsync"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -111,7 +111,7 @@ func testRetrievalRoundTripWithTestCase(t *testing.T, tc testCase) {
 	// TODO: Review after resolution of https://github.com/filecoin-project/go-legs/issues/95
 	// For now instantiate a new host for subscriber so that dt constructed by test client works.
 	subHost := newHost(t)
-	sub, err := legs.NewSubscriber(subHost, client.store, client.lsys, testTopic, nil)
+	sub, err := dagsync.NewSubscriber(subHost, client.store, client.lsys, testTopic, nil)
 	require.NoError(t, err)
 
 	headCid, err := sub.Sync(ctx, server.h.ID(), cid.Undef, nil, server.publisherAddr)
@@ -190,7 +190,7 @@ func testReimportCarWtihTestCase(t *testing.T, tc testCase) {
 	// TODO: Review after resolution of https://github.com/filecoin-project/go-legs/issues/95
 	// For now instantiate a new host for subscriber so that dt constructed by test client works.
 	subHost := newHost(t)
-	sub, err := legs.NewSubscriber(subHost, client.store, client.lsys, testTopic, nil)
+	sub, err := dagsync.NewSubscriber(subHost, client.store, client.lsys, testTopic, nil)
 	require.NoError(t, err)
 
 	headCid, err := sub.Sync(ctx, server.h.ID(), cid.Undef, nil, server.publisherAddr)
@@ -265,7 +265,6 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T, ctx context.Context, o ...engine.Option) *testServer {
-
 	// Explicitly override host so that the host is known for testing purposes.
 	h := newHost(t)
 	store := dssync.MutexWrap(datastore.NewMapDatastore())
@@ -325,7 +324,7 @@ func newTestClient(t *testing.T) *testClient {
 }
 
 func newHost(t *testing.T) host.Host {
-	h, err := libp2p.New()
+	h, err := libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		h.Close()

--- a/engine/doc.go
+++ b/engine/doc.go
@@ -10,6 +10,6 @@
 // For the complete advertisement IPLD schema, see:
 //   - https://github.com/filecoin-project/storetheindex/blob/main/api/v0/ingest/schema/schema.ipldsch
 //
-// The engine internally uses "go-legs" to sync the IPLD DAG of advertisements.
-// See: https://github.com/filecoin-project/go-legs
+// The engine internally uses "storetheindex/dagsync" to sync the IPLD DAG of advertisements.
+// See: https://github.com/filecoin-project/storetheindex/tree/main/dagsync
 package engine

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -218,10 +218,10 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 	})
 
 	// Await subscriber connection to publisher.
-	requireTrueEventually(t, func() bool {
+	require.Eventually(t, func() bool {
 		pubPeers := pubG.ListPeers(topic)
 		return len(pubPeers) == 1 && pubPeers[0] == subHost.ID()
-	}, time.Second, 8*time.Second, "timed out waiting for subscriber peer ID to appear in publisher's gossipsub peer list")
+	}, 8*time.Second, time.Second, "timed out waiting for subscriber peer ID to appear in publisher's gossipsub peer list")
 
 	chunkLnk, err := subject.Chunker().Chunk(ctx, provider.SliceMultihashIterator(mhs))
 	require.NoError(t, err)
@@ -700,22 +700,4 @@ func multiAddsToString(addrs []multiaddr.Multiaddr) []string {
 		rAddrs = append(rAddrs, addr.String())
 	}
 	return rAddrs
-}
-
-func requireTrueEventually(t *testing.T, attempt func() bool, interval time.Duration, timeout time.Duration, msgAndArgs ...interface{}) {
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	for {
-		if attempt() {
-			return
-		}
-		select {
-		case <-ctx.Done():
-			require.FailNow(t, "timed out awaiting eventual success", msgAndArgs...)
-			return
-		case <-ticker.C:
-		}
-	}
 }

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -135,7 +135,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 	// fails. With slow CI machine this sometimes failes, so setting
 	// DirectConnectTicks to 5 is enough to make it reliable.
 	pubG, err := pubsub.NewGossipSub(ctx, pubHost,
-		pubsub.WithDirectConnectTicks(5),
+		pubsub.WithDirectConnectTicks(10),
 		pubsub.WithDirectPeers([]peer.AddrInfo{testutil.WaitForAddrs(subHost)}),
 	)
 	require.NoError(t, err)

--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,8 @@ go 1.18
 
 require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
-	github.com/filecoin-project/go-legs v0.4.16
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/storetheindex v0.4.28
+	github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -205,8 +205,6 @@ github.com/filecoin-project/go-data-transfer v1.15.2 h1:PzqsFr2Q/onMGKrGh7TtRT0d
 github.com/filecoin-project/go-data-transfer v1.15.2/go.mod h1:qXOJ3IF5dEJQHykXXTwcaRxu17bXAxr+LglXzkL6bZQ=
 github.com/filecoin-project/go-ds-versioning v0.1.2 h1:to4pTadv3IeV1wvgbCbN6Vqd+fu+7tveXgv/rCEZy6w=
 github.com/filecoin-project/go-ds-versioning v0.1.2/go.mod h1:C9/l9PnB1+mwPa26BBVpCjG/XQCB0yj/q5CK2J8X1I4=
-github.com/filecoin-project/go-legs v0.4.16 h1:m5Ht1/NTIfJNw8FA+KAsPYfxzqW5AUHbAlNa2EzEkmU=
-github.com/filecoin-project/go-legs v0.4.16/go.mod h1:5ZrHXEhKfVXJXQNOb5mm9pzFuU5xLqY8ZIHQQtYFSSM=
 github.com/filecoin-project/go-state-types v0.1.0 h1:9r2HCSMMCmyMfGyMKxQtv0GKp6VT/m5GgVk8EhYbLJU=
 github.com/filecoin-project/go-state-types v0.1.0/go.mod h1:ezYnPf0bNkTsDibL/psSz5dy4B5awOJ/E7P2Saeep8g=
 github.com/filecoin-project/go-statemachine v0.0.0-20200925024713-05bd7c71fbfe/go.mod h1:FGwQgZAt2Gh5mjlwJUlVB62JeYdo+if0xWxSEfBD9ig=
@@ -215,8 +213,8 @@ github.com/filecoin-project/go-statemachine v1.0.2/go.mod h1:jZdXXiHa61n4NmgWFG4
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/storetheindex v0.4.28 h1:CMAOGyG8aiG+Pu5VsLJemFsW+P50U/tulurib0xOQA4=
-github.com/filecoin-project/storetheindex v0.4.28/go.mod h1:EB+KexIaRJ1BkDuAuJ+t3FLU36VItavLvANIlNhJBPQ=
+github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f h1:BNsZ3RJ2qa2qzcF9KD5vfHaI3CiwWU56QXyTDj0u16M=
+github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f/go.mod h1:S7590oDimBvXMUtzWsBXoshu9HtYKwtXl47zAK9rcP8=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/mirror/doc.go
+++ b/mirror/doc.go
@@ -7,7 +7,7 @@
 // entries entirely. Note that any change to the structure of advertisement will require the ad to
 // be re-signed as the original signature will no longer be valid.
 //
-// A Mirror will also act as a CDN for the original advertisement chain by exposing a legs.Publisher
+// A Mirror will also act as a CDN for the original advertisement chain by exposing a dagsync.Publisher
 // over GraphSync. The endpoint enables an indexer node to fetch the content associated with the
 // original chain of advertisement as well as the mirrored advertisement chain which may be
 // different.

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -388,6 +388,9 @@ func (m *Mirror) remapEntries(ctx context.Context, original ipld.Link) (ipld.Lin
 }
 
 func (m *Mirror) syncAds(ctx context.Context, sel ipld.Node) ([]cid.Cid, error) {
+	if len(m.source.Addrs) == 0 {
+		return nil, errors.New("no address for source")
+	}
 	startSync := time.Now()
 	var syncedAdCids []cid.Cid
 	_, err := m.sub.Sync(ctx, m.source.ID, cid.Undef, sel, m.source.Addrs[0],

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -230,6 +230,9 @@ func (m *Mirror) mirror(ctx context.Context, adCid cid.Cid) error {
 		case schema.NoEntries.Cid:
 			// Nothing to do.
 		default:
+			if len(m.source.Addrs) == 0 {
+				return errors.New("no address for source")
+			}
 			// TODO: it is unfortunate that dagsync takes a single address here... this needs to be
 			//       fixed in storetheindex/dagsync.
 			_, err = m.sub.Sync(ctx, m.source.ID, entriesCid, selectors.entriesWithLimit(m.entriesRecurLimit), m.source.Addrs[0])

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -178,6 +178,7 @@ func (m *Mirror) Start() error {
 }
 
 func (m *Mirror) Shutdown() error {
+	m.ticker.Stop()
 	if m.cancel != nil {
 		m.cancel()
 	}

--- a/mirror/mirror.go
+++ b/mirror/mirror.go
@@ -11,11 +11,11 @@ import (
 	datatransfer "github.com/filecoin-project/go-data-transfer/impl"
 	dtnetwork "github.com/filecoin-project/go-data-transfer/network"
 	gstransport "github.com/filecoin-project/go-data-transfer/transport/graphsync"
-	"github.com/filecoin-project/go-legs"
-	"github.com/filecoin-project/go-legs/dtsync"
 	"github.com/filecoin-project/index-provider/engine/chunker"
 	"github.com/filecoin-project/index-provider/metrics"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/dagsync"
+	"github.com/filecoin-project/storetheindex/dagsync/dtsync"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	"github.com/ipfs/go-datastore/namespace"
@@ -42,8 +42,8 @@ var log = logging.Logger("provider/mirror")
 type Mirror struct {
 	*options
 	source  peer.AddrInfo
-	sub     *legs.Subscriber
-	pub     legs.Publisher
+	sub     *dagsync.Subscriber
+	pub     dagsync.Publisher
 	ls      ipld.LinkSystem
 	chunker *chunker.CachedEntriesChunker
 	cancel  context.CancelFunc
@@ -87,7 +87,7 @@ func New(ctx context.Context, source peer.AddrInfo, o ...Option) (*Mirror, error
 	if err != nil {
 		return nil, err
 	}
-	m.sub, err = legs.NewSubscriber(m.h, nil, m.ls, m.topic, nil, legs.DtManager(dm, gx))
+	m.sub, err = dagsync.NewSubscriber(m.h, nil, m.ls, m.topic, nil, dagsync.DtManager(dm, gx))
 	if err != nil {
 		return nil, err
 	}
@@ -229,8 +229,8 @@ func (m *Mirror) mirror(ctx context.Context, adCid cid.Cid) error {
 		case schema.NoEntries.Cid:
 			// Nothing to do.
 		default:
-			// TODO: it is unfortunate that go-legs takes a single address here... this needs to be
-			//       fixed in go-legs.
+			// TODO: it is unfortunate that dagsync takes a single address here... this needs to be
+			//       fixed in storetheindex/dagsync.
 			_, err = m.sub.Sync(ctx, m.source.ID, entriesCid, selectors.entriesWithLimit(m.entriesRecurLimit), m.source.Addrs[0])
 			if err != nil {
 				log.Errorw("Failed to sync entries", "cid", entriesCid, "err", err)
@@ -391,7 +391,7 @@ func (m *Mirror) syncAds(ctx context.Context, sel ipld.Node) ([]cid.Cid, error) 
 	startSync := time.Now()
 	var syncedAdCids []cid.Cid
 	_, err := m.sub.Sync(ctx, m.source.ID, cid.Undef, sel, m.source.Addrs[0],
-		legs.ScopedBlockHook(func(id peer.ID, c cid.Cid, actions legs.SegmentSyncActions) {
+		dagsync.ScopedBlockHook(func(id peer.ID, c cid.Cid, actions dagsync.SegmentSyncActions) {
 			// TODO: set actions next segment link to ad previous id if it is present. For
 			//      now segmentation is disabled.
 			//       Here we could be encountering HAMT or Entry Chunk so picking the next
@@ -402,7 +402,7 @@ func (m *Mirror) syncAds(ctx context.Context, sel ipld.Node) ([]cid.Cid, error) 
 			syncedAdCids = append([]cid.Cid{c}, syncedAdCids...)
 		}),
 		// Disable segmentation until the actions in hook are handled appropriately
-		legs.ScopedSegmentDepthLimit(-1),
+		dagsync.ScopedSegmentDepthLimit(-1),
 	)
 	elapsedSync := time.Since(startSync)
 	attr := metrics.Attributes.StatusSuccess

--- a/mirror/mirror_env_test.go
+++ b/mirror/mirror_env_test.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"testing"
 
-	"github.com/filecoin-project/go-legs/dtsync"
 	provider "github.com/filecoin-project/index-provider"
 	"github.com/filecoin-project/index-provider/engine"
 	"github.com/filecoin-project/index-provider/metadata"
 	"github.com/filecoin-project/index-provider/mirror"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/dagsync/dtsync"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
@@ -46,7 +46,7 @@ type testEnv struct {
 
 func (te *testEnv) startMirror(t *testing.T, ctx context.Context, opts ...mirror.Option) {
 	var err error
-	te.mirrorHost, err = libp2p.New()
+	te.mirrorHost, err = libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 	// Override the host, since test environment needs explicit access to it.
 	opts = append(opts, mirror.WithHost(te.mirrorHost))
@@ -55,7 +55,7 @@ func (te *testEnv) startMirror(t *testing.T, ctx context.Context, opts ...mirror
 	require.NoError(t, te.mirror.Start())
 	t.Cleanup(func() { require.NoError(t, te.mirror.Shutdown()) })
 
-	te.mirrorSyncHost, err = libp2p.New()
+	te.mirrorSyncHost, err = libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 	te.mirrorSyncHost.Peerstore().AddAddrs(te.mirrorHost.ID(), te.mirrorHost.Addrs(), peerstore.PermanentAddrTTL)
 
@@ -77,7 +77,7 @@ func (te *testEnv) sourceAddrInfo(t *testing.T) peer.AddrInfo {
 
 func (te *testEnv) startSource(t *testing.T, ctx context.Context, opts ...engine.Option) {
 	var err error
-	te.sourceHost, err = libp2p.New()
+	te.sourceHost, err = libp2p.New(libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"))
 	require.NoError(t, err)
 	// Override the host, since test environment needs explicit access to it.
 	opts = append(opts, engine.WithHost(te.sourceHost))

--- a/mirror/mirror_env_test.go
+++ b/mirror/mirror_env_test.go
@@ -6,12 +6,12 @@ import (
 	"fmt"
 	"io"
 	"testing"
-	"time"
 
 	provider "github.com/filecoin-project/index-provider"
 	"github.com/filecoin-project/index-provider/engine"
 	"github.com/filecoin-project/index-provider/metadata"
 	"github.com/filecoin-project/index-provider/mirror"
+	"github.com/filecoin-project/index-provider/testutil"
 	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
 	"github.com/filecoin-project/storetheindex/dagsync/dtsync"
 	"github.com/ipfs/go-cid"
@@ -73,20 +73,7 @@ func (te *testEnv) startMirror(t *testing.T, ctx context.Context, opts ...mirror
 
 func (te *testEnv) sourceAddrInfo(t *testing.T) peer.AddrInfo {
 	require.NotNil(t, te.sourceHost, "start source first")
-	addrInfo := te.sourceHost.Peerstore().PeerInfo(te.sourceHost.ID())
-
-	// If peerstore does not have addresses, delay and retry, up to 10 times.
-	var tries int
-	for len(addrInfo.Addrs) == 0 {
-		if tries == 10 {
-			break
-		}
-		tries++
-		time.Sleep(500 * time.Millisecond)
-		addrInfo = te.sourceHost.Peerstore().PeerInfo(te.sourceHost.ID())
-	}
-
-	return addrInfo
+	return testutil.WaitForAddrs(te.sourceHost)
 }
 
 func (te *testEnv) startSource(t *testing.T, ctx context.Context, opts ...engine.Option) {

--- a/mirror/mirror_test.go
+++ b/mirror/mirror_test.go
@@ -50,7 +50,7 @@ func TestMirror_PutAdIsMirrored(t *testing.T) {
 	originalAdCid := te.putAdOnSource(t, ctx, wantCtxID, wantMhs, wantMetadata)
 
 	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
-	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.Second))
 
 	// Eventually require some head ad CID at the mirror.
 	var gotMirroredHeadCid cid.Cid
@@ -80,7 +80,7 @@ func TestMirror_IsAlsoCdnForOriginalAds(t *testing.T) {
 	ad4 := te.removeAdOnSource(t, ctx, []byte("ad1"))
 
 	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
-	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.Second))
 
 	// Eventually require all original ads to be retrievable from the mirror.
 	var err error
@@ -117,7 +117,7 @@ func TestMirror_FormsExpectedAdChain(t *testing.T) {
 	originalHeadAdCid := te.removeAdOnSource(t, ctx, []byte("ad1"))
 
 	// Start a mirror for the original provider with reduced tick time for faster test turnaround.
-	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.Second))
 
 	// Await until the entire chain is mirrored; this is done by checking if the head mirrored ad
 	// is a removal.
@@ -201,7 +201,7 @@ func TestMirror_FormsExpectedAdChainRemap(t *testing.T) {
 			_ = te.removeAdOnSource(t, ctx, []byte("ad2"))
 			originalHeadAdCid := te.putAdOnSource(t, ctx, []byte("ad5"), testutil.RandomMultihashes(t, rng, 7), md)
 
-			test.mirrorOptions = append(test.mirrorOptions, mirror.WithSyncInterval(time.NewTicker(time.Second)))
+			test.mirrorOptions = append(test.mirrorOptions, mirror.WithSyncInterval(time.Second))
 			te.startMirror(t, ctx, test.mirrorOptions...)
 
 			// Await until the entire chain is mirrored; this is done by checking if the head mirrored ad
@@ -239,7 +239,7 @@ func TestMirror_PreviousIDIsPreservedOnStartFromPartialAdChain(t *testing.T) {
 	orignalHeadCid := te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 3), md)
 
 	// Start mirror with maximum initial depth of 2.
-	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)), mirror.WithInitialAdRecursionLimit(selector.RecursionLimitDepth(2)))
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.Second), mirror.WithInitialAdRecursionLimit(selector.RecursionLimitDepth(2)))
 
 	var gotMirroredHeadAdCid cid.Cid
 	var err error
@@ -295,7 +295,7 @@ func TestMirror_MirrorsAdsIdenticallyWhenConfiguredTo(t *testing.T) {
 	_ = te.removeAdOnSource(t, ctx, []byte("ad1"))
 	originalHeadCid := te.putAdOnSource(t, ctx, []byte("ad3"), testutil.RandomMultihashes(t, rng, 3), md)
 
-	te.startMirror(t, ctx, mirror.WithSyncInterval(time.NewTicker(time.Second)), mirror.WithAlwaysReSignAds(false))
+	te.startMirror(t, ctx, mirror.WithSyncInterval(time.Second), mirror.WithAlwaysReSignAds(false))
 
 	var gotMirroredHeadAdCid cid.Cid
 	var err error

--- a/mirror/options.go
+++ b/mirror/options.go
@@ -40,7 +40,6 @@ type (
 
 func newOptions(o ...Option) (*options, error) {
 	opts := options{
-		ticker:            time.NewTicker(10 * time.Minute),
 		initAdRecurLimit:  selector.RecursionLimitNone(),
 		entriesRecurLimit: selector.RecursionLimitNone(),
 		chunkCacheCap:     1024,
@@ -61,6 +60,10 @@ func newOptions(o ...Option) (*options, error) {
 	if opts.ds == nil {
 		opts.ds = dssync.MutexWrap(datastore.NewMapDatastore())
 	}
+	if opts.ticker == nil {
+		opts.ticker = time.NewTicker(10 * time.Minute)
+	}
+
 	return &opts, nil
 }
 
@@ -129,9 +132,9 @@ func WithSkipRemapOnEntriesTypeMatch(s bool) Option {
 // WithSyncInterval specifies the time interval at which the original provider is checked for new
 // advertisements.
 // If unset, the default time interval of 10 minutes is used.
-func WithSyncInterval(t *time.Ticker) Option {
+func WithSyncInterval(interval time.Duration) Option {
 	return func(o *options) error {
-		o.ticker = t
+		o.ticker = time.NewTicker(interval)
 		return nil
 	}
 }

--- a/mirror/selectors.go
+++ b/mirror/selectors.go
@@ -1,7 +1,7 @@
 package mirror
 
 import (
-	"github.com/filecoin-project/go-legs"
+	"github.com/filecoin-project/storetheindex/dagsync"
 	"github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/node/basicnode"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
@@ -30,6 +30,6 @@ func init() {
 		return ssb.ExploreRecursive(limit, adSequenceBuilder).Node()
 	}
 	selectors.adsWithStopAt = func(limit selector.RecursionLimit, stop ipld.Link) ipld.Node {
-		return legs.ExploreRecursiveWithStopNode(limit, adSequenceBuilder.Node(), stop)
+		return dagsync.ExploreRecursiveWithStopNode(limit, adSequenceBuilder.Node(), stop)
 	}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -157,3 +157,19 @@ func CopyFile(t *testing.T, src, dst string) {
 	_, err = io.Copy(dstfd, srcfd)
 	require.NoError(t, err)
 }
+
+// Sometimes the peerstore is not populated immediately. This is resolved by a
+// delay and retry.
+func WaitForAddrs(h host.Host) peer.AddrInfo {
+	addrInfo := h.Peerstore().PeerInfo(h.ID())
+	var tries int
+	for len(addrInfo.Addrs) == 0 {
+		if tries == 10 {
+			break
+		}
+		tries++
+		time.Sleep(500 * time.Millisecond)
+		addrInfo = h.Peerstore().PeerInfo(h.ID())
+	}
+	return addrInfo
+}


### PR DESCRIPTION
All functionality from go-legs has moved to storetheindex/dagsync.

For tests, bind libp2p hosts to local interface to avoid problems with testing when using various VPNs.
