### PR TITLE
Add extended providers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,33 @@ advertise content, see:
 
 * [`engine/example_test.go`](engine/example_test.go)
 
+#### Publishing ads with extended providers
+
+[Extended providers](https://github.com/filecoin-project/storetheindex/blob/main/doc/ingest.md#extendedprovider) 
+field allows for specification of provider families, in cases where a provider operates multiple PeerIDs, perhaps 
+with different transport protocols between them, but over the same database of content. 
+
+Such ads can be composed manually or using a convenience builder `ExtendedProvidersAdBuilder`.
+```
+
+  adv, err := ep.NewExtendedProviderAdBuilder(providerID, priv, addrs). // the main ad's providerID, private key and addresses
+    WithContextID(contextID). // optional context id
+    WithMetadata(metadata). // optional metadata
+    WithOverride(override). // override flag, false by default
+    WithExtendedProviders(extendedProviders). // one or more extended providers to be included in the ad, represented by ExtendedProviderInfo struct
+    WithLastAdID(lastAdId). // cid of the last published ad, which is false by default
+    BuildAndSign()
+
+  if err != nil {
+    //...
+  }
+
+  engine.Publish(ctx, *adv)
+)
+```
+
+> Identity of the main provider will be added to the extended providers list automatically and should not be passed in explicitly
+
 ### `provider` CLI
 
 The `provider` CLI can be used to interact with a running daemon via the admin server to perform a
@@ -243,6 +270,7 @@ advertisement. The cache expansion is logged in `INFO` level at `provider/engine
 * [Indexer Node Design](https://www.notion.so/protocollabs/Indexer-Node-Design-4fb94471b6be4352b6849dc9b9527825)
 * [Providing data to a network indexer](https://github.com/filecoin-project/storetheindex/blob/main/doc/ingest.md)
 * [`storetheindex`](https://github.com/filecoin-project/storetheindex): indexer node implementation
+* [`storetheindex` documentation](https://github.com/filecoin-project/storetheindex/blob/main/doc/)
 * [`go-indexer-core`](https://github.com/filecoin-project/go-indexer-core): Core index key-value
   store
 

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -49,7 +49,7 @@ func TestEngine_NotifyRemoveWithUnknownContextIDIsError(t *testing.T) {
 
 func Test_NewEngineWithNoPublisherAndRoot(t *testing.T) {
 	rng := rand.New(rand.NewSource(1413))
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	mhs := testutil.RandomMultihashes(t, rng, 1)
 	contextID := []byte("fish")
 
@@ -73,7 +73,7 @@ func Test_NewEngineWithNoPublisherAndRoot(t *testing.T) {
 }
 
 func TestEngine_PublishLocal(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -92,7 +92,7 @@ func TestEngine_PublishLocal(t *testing.T) {
 	require.NoError(t, err)
 	wantAd := schema.Advertisement{
 		Provider:  subject.Host().ID().String(),
-		Addresses: multiAddsToString(subject.Host().Addrs()),
+		Addresses: testutil.MultiAddsToString(subject.Host().Addrs()),
 		Entries:   chunkLnk,
 		ContextID: []byte("fish"),
 		Metadata:  mdBytes,
@@ -111,7 +111,7 @@ func TestEngine_PublishLocal(t *testing.T) {
 }
 
 func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -240,7 +240,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 
 	wantAd := schema.Advertisement{
 		Provider:  subject.Host().ID().String(),
-		Addresses: multiAddsToString(subject.Host().Addrs()),
+		Addresses: testutil.MultiAddsToString(subject.Host().Addrs()),
 		Entries:   chunkLnk,
 		ContextID: wantContextID,
 		Metadata:  mdBytes,
@@ -311,7 +311,7 @@ func TestEngine_PublishWithDataTransferPublisher(t *testing.T) {
 }
 
 func TestEngine_NotifyPutWithoutListerIsError(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	subject, err := engine.New()
 	require.NoError(t, err)
 	err = subject.Start(ctx)
@@ -324,7 +324,7 @@ func TestEngine_NotifyPutWithoutListerIsError(t *testing.T) {
 }
 
 func TestEngine_NotifyPutThenNotifyRemove(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -362,7 +362,7 @@ func TestEngine_NotifyPutThenNotifyRemove(t *testing.T) {
 }
 
 func TestEngine_NotifyRemoveWithDefaultProvider(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -394,7 +394,7 @@ func TestEngine_NotifyRemoveWithDefaultProvider(t *testing.T) {
 }
 
 func TestEngine_NotifyRemoveWithCustomProvider(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -428,7 +428,7 @@ func TestEngine_NotifyRemoveWithCustomProvider(t *testing.T) {
 }
 
 func TestEngine_ProducesSingleChainForMultipleProviders(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs1 := testutil.RandomMultihashes(t, rng, 42)
@@ -480,7 +480,7 @@ func TestEngine_ProducesSingleChainForMultipleProviders(t *testing.T) {
 }
 
 func TestEngine_NotifyPutUseDefaultProviderAndAddressesWhenNoneGiven(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -512,7 +512,7 @@ func TestEngine_NotifyPutUseDefaultProviderAndAddressesWhenNoneGiven(t *testing.
 }
 
 func TestEngine_VerifyErrAlreadyAdvertised(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -544,7 +544,7 @@ func TestEngine_VerifyErrAlreadyAdvertised(t *testing.T) {
 }
 
 func TestEngine_ShouldHaveSameChunksInChunkerForSameCIDs(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	rng := rand.New(rand.NewSource(1413))
 
 	mhs := testutil.RandomMultihashes(t, rng, 42)
@@ -610,7 +610,7 @@ func TestEngine_DatastoreBackwardsCompatibilityTest(t *testing.T) {
 	ma3, _ := multiaddr.NewMultiaddr("/ip4/127.0.0.1/tcp/62695")
 	pID, _ := peer.Decode("QmPxKFBM2A7VZURXZhZLCpEnhMFtZ7WSZwFLneFEiYneES")
 
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 	subject, err := engine.New(engine.WithDatastore(ds), engine.WithProvider(peer.AddrInfo{ID: pID, Addrs: []multiaddr.Multiaddr{ma1, ma2, ma3}}))
 	require.NoError(t, err)
 	err = subject.Start(ctx)
@@ -683,12 +683,6 @@ func verifyAd(t *testing.T, ctx context.Context, subject *engine.Engine, expecte
 	}
 }
 
-func contextWithTimeout(t *testing.T) context.Context {
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	t.Cleanup(cancel)
-	return ctx
-}
-
 func requireEqualDagsyncMessage(t *testing.T, got, want gossiptopic.Message) {
 	require.Equal(t, want.Cid, got.Cid)
 	require.Equal(t, want.ExtraData, got.ExtraData)
@@ -696,17 +690,9 @@ func requireEqualDagsyncMessage(t *testing.T, got, want gossiptopic.Message) {
 	require.NoError(t, err)
 	gotAddrs, err := got.GetAddrs()
 	require.NoError(t, err)
-	wantAddrsStr := multiAddsToString(wantAddrs)
+	wantAddrsStr := testutil.MultiAddsToString(wantAddrs)
 	sort.Strings(wantAddrsStr)
-	gotAddrsStr := multiAddsToString(gotAddrs)
+	gotAddrsStr := testutil.MultiAddsToString(gotAddrs)
 	sort.Strings(gotAddrsStr)
 	require.Equal(t, wantAddrsStr, gotAddrsStr)
-}
-
-func multiAddsToString(addrs []multiaddr.Multiaddr) []string {
-	var rAddrs []string
-	for _, addr := range addrs {
-		rAddrs = append(rAddrs, addr.String())
-	}
-	return rAddrs
 }

--- a/engine/linksystem_test.go
+++ b/engine/linksystem_test.go
@@ -26,7 +26,7 @@ import (
 var testMetadata = metadata.Default.New(metadata.Bitswap{})
 
 func Test_SchemaNoEntriesErr(t *testing.T) {
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 
 	subject, err := engine.New()
 	require.NoError(t, err)
@@ -40,7 +40,7 @@ func Test_SchemaNoEntriesErr(t *testing.T) {
 
 func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 	rng := rand.New(rand.NewSource(1413))
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 
 	subject, err := engine.New()
 	require.NoError(t, err)
@@ -100,7 +100,7 @@ func Test_RemovalAdvertisementWithNoEntriesIsRetrievable(t *testing.T) {
 
 func Test_EvictedCachedEntriesChainIsRegeneratedGracefully(t *testing.T) {
 	rng := rand.New(rand.NewSource(1413))
-	ctx := contextWithTimeout(t)
+	ctx := testutil.ContextWithTimeout(t)
 
 	chunkSize := 2
 	cacheCap := 1

--- a/engine/xproviders/xproviders.go
+++ b/engine/xproviders/xproviders.go
@@ -1,0 +1,164 @@
+package xproviders
+
+import (
+	"errors"
+
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/ipfs/go-cid"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// AdBuilder contains fields required for building and signing of a new ad with Extended Providers
+type AdBuilder struct {
+	// providerID contains a peer ID of the main provider (the one from the body of the ad)
+	providerID string
+	// privKey contains a private key of the main provider
+	privKey crypto.PrivKey
+	// addrs contains addresses of the main provider
+	addrs []string
+	// providers contains providers' identities, keys, metadata and addresses that will be used as extended providers in the ad.
+	providers []Info
+	// contextID contains optional context id
+	contextID []byte
+	// contextID contains optional metadata
+	metadata []byte
+	// override contains override flag that is false by default
+	override bool
+	// lastAdID contains optional last ad cid which is cid.Undef by default
+	lastAdID cid.Cid
+}
+
+// Info contains information about extended provider.
+type Info struct {
+	// ID contains peer ID of the extended provider
+	ID string
+	// Metadata contains optional metadata of the extended provider
+	Metadata []byte
+	// Addrs contains a list of extended provider's addresses
+	Addrs []string
+	// Priv contains a provtae key of the extended provider
+	Priv crypto.PrivKey
+}
+
+// NewAdBuilder creates a new ExtendedProvidersAdBuilder
+func NewAdBuilder(providerID peer.ID, privKey crypto.PrivKey, addrs []ma.Multiaddr) *AdBuilder {
+	pub := &AdBuilder{
+		providerID: providerID.String(),
+		privKey:    privKey,
+		addrs:      multiaddrsToStrings(addrs),
+		providers:  []Info{},
+		lastAdID:   cid.Undef,
+	}
+	return pub
+}
+
+// WithContextID sets contextID
+func (pub *AdBuilder) WithContextID(contextID []byte) *AdBuilder {
+	pub.contextID = contextID
+	return pub
+}
+
+// WithMetadata sets metadata
+func (pub *AdBuilder) WithMetadata(md []byte) *AdBuilder {
+	pub.metadata = md
+	return pub
+}
+
+// WithOverride sets override
+func (pub *AdBuilder) WithOverride(override bool) *AdBuilder {
+	pub.override = override
+	return pub
+}
+
+// WithExtendedProviders sets extended providers
+func (pub *AdBuilder) WithExtendedProviders(eps ...Info) *AdBuilder {
+	pub.providers = append(pub.providers, eps...)
+	return pub
+}
+
+// WithLastAdID sets last ad cid
+func (pub *AdBuilder) WithLastAdID(lastAdID cid.Cid) *AdBuilder {
+	pub.lastAdID = lastAdID
+	return pub
+}
+
+// BuildAndSign verifies and  signs a new extended provider ad. After that it can be published using engine. Identity of the main provider will be appended to the
+// extended provider list automatically.
+func (pub *AdBuilder) BuildAndSign() (*schema.Advertisement, error) {
+	if len(pub.providers) == 0 {
+		return nil, errors.New("providers list is empty")
+	}
+
+	if len(pub.contextID) == 0 && pub.override {
+		return nil, errors.New("override is true for empty context")
+	}
+
+	adv := schema.Advertisement{
+		Provider:  pub.providerID,
+		Entries:   schema.NoEntries,
+		Addresses: pub.addrs,
+		ContextID: pub.contextID,
+		Metadata:  pub.metadata,
+		ExtendedProvider: &schema.ExtendedProvider{
+			Override: pub.override,
+		},
+	}
+
+	epMap := map[string]Info{}
+	for _, epInfo := range pub.providers {
+		adv.ExtendedProvider.Providers = append(adv.ExtendedProvider.Providers, schema.Provider{
+			ID:        epInfo.ID,
+			Addresses: epInfo.Addrs,
+			Metadata:  epInfo.Metadata,
+		})
+		epMap[epInfo.ID] = epInfo
+	}
+
+	// The main provider has to be on the extended list too
+	adv.ExtendedProvider.Providers = append(adv.ExtendedProvider.Providers, schema.Provider{
+		ID:        pub.providerID,
+		Addresses: pub.addrs,
+		Metadata:  pub.metadata,
+	})
+
+	if pub.lastAdID != cid.Undef {
+		prev := ipld.Link(cidlink.Link{Cid: pub.lastAdID})
+		adv.PreviousID = prev
+	}
+
+	err := adv.SignWithExtendedProviders(pub.privKey, func(provId string) (crypto.PrivKey, error) {
+		epInfo, ok := epMap[provId]
+		if !ok {
+			return nil, errors.New("unknown provider")
+		}
+		return epInfo.Priv, nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &adv, nil
+}
+
+// NewInfo allows to create a new ExtendedProviderInfo providing type safety around its fields
+func NewInfo(peerID peer.ID, priv crypto.PrivKey, metadata []byte, addrs []ma.Multiaddr) Info {
+	return Info{
+		ID:       peerID.String(),
+		Metadata: metadata,
+		Addrs:    multiaddrsToStrings(addrs),
+		Priv:     priv,
+	}
+}
+
+func multiaddrsToStrings(addrs []ma.Multiaddr) []string {
+	var stringAddrs []string
+	for _, addr := range addrs {
+		stringAddrs = append(stringAddrs, addr.String())
+	}
+	return stringAddrs
+}

--- a/engine/xproviders/xproviders_test.go
+++ b/engine/xproviders/xproviders_test.go
@@ -1,0 +1,128 @@
+package xproviders_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/filecoin-project/index-provider/engine"
+	ep "github.com/filecoin-project/index-provider/engine/xproviders"
+	"github.com/filecoin-project/index-provider/testutil"
+	"github.com/filecoin-project/storetheindex/api/v0/ingest/schema"
+	"github.com/filecoin-project/storetheindex/test/util"
+	"github.com/ipfs/go-cid"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPublish(t *testing.T) {
+	ctx := testutil.ContextWithTimeout(t)
+	contextID := []byte("test-context")
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
+	metadata := make([]byte, 0, 10)
+	rng.Read(metadata)
+	eps := make([]ep.Info, 2)
+	epIds := make([]peer.ID, len(eps))
+
+	eng, err := engine.New()
+	require.NoError(t, err)
+	err = eng.Start(ctx)
+	require.NoError(t, err)
+	defer eng.Shutdown()
+
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	for i := 0; i < len(eps); i++ {
+		epID, ep := randomExtendedProvider(t)
+		eps[i] = ep
+		epIds[i] = epID
+	}
+
+	override := true
+	adv, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(eps...).
+		WithOverride(true).
+		WithContextID(contextID).
+		WithMetadata(metadata).
+		BuildAndSign()
+	require.NoError(t, err)
+	advPeerID, err := adv.VerifySignature()
+	require.NoError(t, err)
+
+	// verify that we can publish successfully
+	c, err := eng.Publish(ctx, *adv)
+	require.NoError(t, err)
+	require.NotEqual(t, cid.Undef, c)
+
+	require.Equal(t, providerID, advPeerID)
+	require.Equal(t, testutil.MultiAddsToString(addrs), adv.Addresses)
+	require.Equal(t, contextID, adv.ContextID)
+	require.Equal(t, schema.NoEntries, adv.Entries)
+	require.Equal(t, false, adv.IsRm)
+	require.Equal(t, metadata, adv.Metadata)
+	require.Equal(t, providerID.String(), adv.Provider)
+	require.Equal(t, override, adv.ExtendedProvider.Override)
+	require.Equal(t, 3, len(adv.ExtendedProvider.Providers))
+
+	ep1 := eps[0]
+	ep2 := eps[1]
+	for _, p := range adv.ExtendedProvider.Providers {
+		switch p.ID {
+		case ep1.ID:
+			require.Equal(t, ep1.Addrs, p.Addresses)
+			require.Equal(t, ep1.Metadata, p.Metadata)
+		case ep2.ID:
+			require.Equal(t, ep2.Addrs, p.Addresses)
+			require.Equal(t, ep2.Metadata, p.Metadata)
+		case providerID.String():
+			require.Equal(t, testutil.MultiAddsToString(addrs), p.Addresses)
+			require.Equal(t, metadata, p.Metadata)
+		default:
+			panic("unknown provider")
+		}
+	}
+
+}
+
+func TestPublishFailsIfOverrideIsTrueWithNoContextId(t *testing.T) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	addrs := util.StringToMultiaddrs(t, []string{"/ip4/0.0.0.0/tcp/3090", "/ip4/0.0.0.0/tcp/3091"})
+	metadata := make([]byte, 0, 10)
+	rng.Read(metadata)
+	eps := make([]ep.Info, 2)
+	epIds := make([]peer.ID, len(eps))
+	for i := 0; i < len(eps); i++ {
+		epID, ep := randomExtendedProvider(t)
+		eps[i] = ep
+		epIds[i] = epID
+	}
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+
+	_, err := ep.NewAdBuilder(providerID, priv, addrs).
+		WithExtendedProviders(eps...).
+		WithOverride(true).
+		WithMetadata(metadata).
+		BuildAndSign()
+
+	require.Error(t, err, "override is true for empty context")
+}
+
+func randomExtendedProvider(t *testing.T) (peer.ID, ep.Info) {
+	rng := rand.New(rand.NewSource(time.Now().Unix()))
+	priv, _, providerID := testutil.GenerateKeysAndIdentity(t)
+	metadata := make([]byte, 0, 20)
+	_, err := rng.Read(metadata)
+	require.NoError(t, err)
+	addrs := make([]multiaddr.Multiaddr, 0, 2)
+	for i := 0; i < len(addrs); i++ {
+		s := fmt.Sprintf("/ip4/%d.%d.%d.%d/tcp/%d", rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%255, rng.Int()%10000+1024)
+		ma, err := multiaddr.NewMultiaddr(s)
+		require.NoError(t, err)
+		addrs[i] = ma
+	}
+
+	return providerID, ep.NewInfo(providerID, priv, metadata, addrs)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/filecoin-project/go-data-transfer v1.15.2
 	github.com/filecoin-project/go-state-types v0.1.0
-	github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f
+	github.com/filecoin-project/storetheindex v0.4.30-0.20221114113647-683091f8e893
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/filecoin-project/go-statemachine v1.0.2/go.mod h1:jZdXXiHa61n4NmgWFG4
 github.com/filecoin-project/go-statestore v0.1.0/go.mod h1:LFc9hD+fRxPqiHiaqUEZOinUJB4WARkRfNl10O7kTnI=
 github.com/filecoin-project/go-statestore v0.2.0 h1:cRRO0aPLrxKQCZ2UOQbzFGn4WDNdofHZoGPjfNaAo5Q=
 github.com/filecoin-project/go-statestore v0.2.0/go.mod h1:8sjBYbS35HwPzct7iT4lIXjLlYyPor80aU7t7a/Kspo=
-github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f h1:BNsZ3RJ2qa2qzcF9KD5vfHaI3CiwWU56QXyTDj0u16M=
-github.com/filecoin-project/storetheindex v0.4.30-0.20221109085212-74031627a73f/go.mod h1:S7590oDimBvXMUtzWsBXoshu9HtYKwtXl47zAK9rcP8=
+github.com/filecoin-project/storetheindex v0.4.30-0.20221114113647-683091f8e893 h1:6GCuzxLVHBzlz7y+FkbHh6n0UyoEGWqDwJKQPJoz7bE=
+github.com/filecoin-project/storetheindex v0.4.30-0.20221114113647-683091f8e893/go.mod h1:S7590oDimBvXMUtzWsBXoshu9HtYKwtXl47zAK9rcP8=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/noise v1.0.0 h1:DlTHqmzmvcEiKj+4RYo/imoswx/4r6iBlCMfVtrMXpQ=
 github.com/flynn/noise v1.0.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=

--- a/reframe/listener_concurrency_test.go
+++ b/reframe/listener_concurrency_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/filecoin-project/index-provider/engine"
 	mock_provider "github.com/filecoin-project/index-provider/mock"
 	reframelistener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/filecoin-project/index-provider/testutil"
 	"github.com/golang/mock/gomock"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -25,7 +26,7 @@ func TestHandleConcurrentRequests(t *testing.T) {
 	snapshotSize := 1000
 	concurrencyFactor := 10
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -78,7 +79,7 @@ func TestShouldProcessMillionCIDsInThirtySeconds(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))

--- a/reframe/listener_test.go
+++ b/reframe/listener_test.go
@@ -2,7 +2,6 @@ package reframe_test
 
 import (
 	"context"
-	"crypto/rand"
 	"crypto/sha256"
 	"fmt"
 	"net/http/httptest"
@@ -14,6 +13,7 @@ import (
 	"github.com/filecoin-project/index-provider/metadata"
 	mock_provider "github.com/filecoin-project/index-provider/mock"
 	reframelistener "github.com/filecoin-project/index-provider/reframe"
+	"github.com/filecoin-project/index-provider/testutil"
 	"github.com/golang/mock/gomock"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
@@ -56,7 +56,7 @@ func TestReframeMultihashLister(t *testing.T) {
 	cids[newCid("test2")] = struct{}{}
 	cids[newCid("test3")] = struct{}{}
 
-	_, pID := generateKeyAndIdentity(t)
+	_, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	lister := &reframelistener.ReframeMultihashLister{
 		CidFetcher: func(contextID []byte) (map[cid.Cid]struct{}, error) {
@@ -120,7 +120,7 @@ func TestProvideRoundtrip(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -179,7 +179,7 @@ func TestProvideRoundtripWithRemove(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -235,7 +235,7 @@ func TestAdvertiseTwoChunksWithOneCidInEach(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -266,7 +266,7 @@ func TestAdvertiseUsingAddrsFromParameters(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -301,7 +301,7 @@ func TestProvideRegistersCidInDatastore(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -336,7 +336,7 @@ func TestCidsAreOrderedByArrivalInExpiryQueue(t *testing.T) {
 	chunkSize := 1000
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -371,7 +371,7 @@ func TestFullChunkAdvertisedAndRegisteredInDatastore(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -408,7 +408,7 @@ func TestRemovedChunkIsRemovedFromIndexes(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -447,7 +447,7 @@ func TestAdvertiseOneChunkWithTwoCidsInIt(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -477,7 +477,7 @@ func TestDoNotReAdvertiseRepeatedCids(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -510,7 +510,7 @@ func TestAdvertiseExpiredCidsIfProvidedAgain(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -548,7 +548,7 @@ func TestRemoveExpiredCidAndReadvertiseChunk(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -592,7 +592,7 @@ func TestExpireMultipleChunks(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -630,7 +630,7 @@ func TestDoNotReadvertiseChunkIfAllCidsExpired(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -668,7 +668,7 @@ func TestDoNoLoadRemovedChunksOnInitialisation(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -708,7 +708,7 @@ func TestMissingCidTimestampsBackfilledOnIntialisation(t *testing.T) {
 	chunkSize := 1
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -773,7 +773,7 @@ func TestSameCidNotDuplicatedInTheCurrentChunkIfProvidedTwice(t *testing.T) {
 	chunkSize := 2
 	snapshotSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -802,7 +802,7 @@ func TestShouldStoreSnapshotInDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -843,7 +843,7 @@ func TestShouldNotStoreSnapshotInDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -882,7 +882,7 @@ func TestShouldCleanUpTimestampMappingsFromDatastore(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -928,7 +928,7 @@ func TestShouldCorrectlyMergeSnapshotAndCidTimestamps(t *testing.T) {
 	ttl := time.Hour
 	chunkSize := 1000
 
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -980,7 +980,7 @@ func TestInitialiseFromDatastoreWithSnapshot(t *testing.T) {
 }
 
 func verifyInitialisationFromDatastore(t *testing.T, snapshotSize int, ttl time.Duration, chunkSize int) {
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1035,7 +1035,7 @@ func TestCleanUpExpiredCidsThatDontHaveChunk(t *testing.T) {
 	ttl := time.Second
 	chunkSize := 2
 	snapshotSize := 1000
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1076,7 +1076,7 @@ func TestCidsWithoutChunkAreRegisteredInDsAndIndexes(t *testing.T) {
 	ttl := 1 * time.Hour
 	chunkSize := 2
 	snapshotSize := 1000
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 
 	ctx := context.Background()
 	defer ctx.Done()
@@ -1109,7 +1109,7 @@ func TestShouldSplitSnapshotIntoMultipleChunksAndReadThemBack(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1174,7 +1174,7 @@ func TestShouldCleanUpOldSnapshotChunksAfterStoringNewOnes(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1221,7 +1221,7 @@ func TestShouldRecogniseLegacySnapshot(t *testing.T) {
 
 	h, err := libp2p.New()
 	require.NoError(t, err)
-	priv, pID := generateKeyAndIdentity(t)
+	priv, _, pID := testutil.GenerateKeysAndIdentity(t)
 	ctx := context.Background()
 
 	engine, err := engine.New(engine.WithHost(h), engine.WithPublisherKind(engine.DataTransferPublisher))
@@ -1299,14 +1299,6 @@ func generateContextID(cids []string, nonce []byte) []byte {
 func newCid(s string) cid.Cid {
 	testMH1, _ := multihash.Encode([]byte(s), multihash.IDENTITY)
 	return cid.NewCidV1(cid.Raw, testMH1)
-}
-
-func generateKeyAndIdentity(t *testing.T) (crypto.PrivKey, peer.ID) {
-	priv, _, err := crypto.GenerateEd25519Key(rand.Reader)
-	require.NoError(t, err)
-	pID, err := peer.IDFromPrivateKey(priv)
-	require.NoError(t, err)
-	return priv, pID
 }
 
 func createClientAndServer(t *testing.T, service server.DelegatedRoutingService, p *client.Provider, identity crypto.PrivKey) (*client.Client, *httptest.Server) {

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -27,6 +27,7 @@ import (
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/multiformats/go-multiaddr"
 	"github.com/multiformats/go-multihash"
 	"github.com/stretchr/testify/require"
 )
@@ -172,4 +173,26 @@ func WaitForAddrs(h host.Host) peer.AddrInfo {
 		addrInfo = h.Peerstore().PeerInfo(h.ID())
 	}
 	return addrInfo
+}
+
+func GenerateKeysAndIdentity(t *testing.T) (crypto.PrivKey, crypto.PubKey, peer.ID) {
+	priv, pub, err := crypto.GenerateEd25519Key(crand.Reader)
+	require.NoError(t, err)
+	pID, err := peer.IDFromPrivateKey(priv)
+	require.NoError(t, err)
+	return priv, pub, pID
+}
+
+func ContextWithTimeout(t *testing.T) context.Context {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+func MultiAddsToString(addrs []multiaddr.Multiaddr) []string {
+	var rAddrs []string
+	for _, addr := range addrs {
+		rAddrs = append(rAddrs, addr.String())
+	}
+	return rAddrs
 }


### PR DESCRIPTION
This PR adds support for [extended providers](https://github.com/filecoin-project/storetheindex/pull/804/files). It's a *programmatic* API only. CLI and configuration support will follow up if there going to be a need for those. 

In particular, the PR adds `xproviders.AdBuilder` class - a builder for constructing, signing and verifying an ad that can be then published using `Engine`.
